### PR TITLE
feat: full nix-darwin setup for all Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,81 +1,114 @@
 # dotfiles
 
-Declarative home configuration using [Nix flakes](https://wiki.nixos.org/wiki/Flakes) and [home-manager](https://github.com/nix-community/home-manager).
+Declarative Mac + Linux configuration using [Nix flakes](https://wiki.nixos.org/wiki/Flakes), [nix-darwin](https://github.com/LnL7/nix-darwin), and [home-manager](https://github.com/nix-community/home-manager).
 
-## What's included
+## Machines
 
-| Module | Description |
-|---|---|
-| `modules/common.nix` | Core CLI tools (curl, jq, git, ripgrep, fd, tree, htop), git config, bash aliases |
-| `modules/editors/vim.nix` | Neovim with sensible defaults (line numbers, smart tabs, case-insensitive search) |
-| `modules/dev-tools/docker.nix` | docker-compose, lazydocker (Linux only) |
-
-## Configurations
-
-| Name | System | Usage |
+| Hostname | Machine | Role |
 |---|---|---|
-| `linux` | aarch64-linux | OrbStack VM or Docker container |
-| `mac` | aarch64-darwin | macOS Apple Silicon |
+| `m5-air` | MacBook Air M5 | Daily driver |
+| `rouven-air-m3` | MacBook Air M3 | Mobile |
+| `rouven-pro-m4` | MacBook Pro M4 | Mobile |
+| `rouvens-mac-mini` | Mac Mini M4 | Office desktop |
+| `rouvens-mac-studio` | Mac Studio M3 Ultra | AI inference lab |
+| `linux` | OrbStack NixOS VM | Dev services |
+| `jetson` | Jetson AGX Orin | Edge inference |
+| `contabo` | Contabo VPS | Server |
 
-## Usage
-
-### Prerequisites
-
-- [Nix](https://nixos.org/download/) with flakes enabled
-- Add to `/etc/nix/nix.conf`: `experimental-features = nix-command flakes`
-
-### Apply configuration
-
-```bash
-# Clone
-git clone https://github.com/rh7/dotfiles.git
-cd dotfiles
-
-# Linux
-nix run home-manager -- switch --flake .#linux -b backup
-
-# macOS (Apple Silicon)
-nix run home-manager -- switch --flake .#mac -b backup
-```
-
-### Use the dev shell
+## Fresh Mac Setup
 
 ```bash
-cd dotfiles
-nix develop    # drops into a shell with git, curl, jq
+# One command — works on any machine listed above
+bash <(curl -fsSL https://raw.githubusercontent.com/rh7/dotfiles/main/bootstrap.sh)
+
+# After iCloud syncs
+mackup restore
 ```
 
-### Update dependencies
+## Apply Config Changes
 
 ```bash
-nix flake update    # updates flake.lock to latest nixpkgs + home-manager
-nix run home-manager -- switch --flake .#linux -b backup   # re-apply
+darwin-rebuild switch --flake ~/dotfiles   # full form
+nrs                                         # alias (after first setup)
 ```
+
+## Settings Sync Strategy
+
+| What | How |
+|---|---|
+| macOS defaults, dock, keyboard | nix-darwin (`nrs`) |
+| CLI tools, dev toolchains | Nix / Home Manager (`nrs`) |
+| Shell, git, SSH config | Home Manager (`nrs`) |
+| App preferences (Cursor, Zed, Slack...) | mackup → iCloud |
+| SSH keys | 1Password SSH Agent |
+| Cursor settings | Cursor built-in sync (GitHub) |
+| Obsidian vault | iCloud / Dropbox |
+| Arc bookmarks/spaces | Arc account sync |
+| Secrets / env vars | 1Password CLI (`op run`) |
 
 ## Structure
 
 ```
 .
-├── flake.nix                          # Entry point: inputs, outputs, configurations
-├── flake.lock                         # Pinned dependency versions
+├── bootstrap.sh                    # Fresh Mac setup script
+├── flake.nix                       # Entry point: all machines defined here
+├── flake.lock                      # Pinned dependency versions
 ├── configurations/
-│   ├── linux/home.nix                 # Linux-specific: username, home dir
-│   └── macos/home.nix                 # macOS-specific: username, home dir
+│   ├── macos/
+│   │   ├── home.nix                # Shared macOS user config + toolchains
+│   │   ├── macbook.nix             # MacBook-specific apps
+│   │   ├── mac-mini-office.nix     # Office Mac Mini (smart home, Office)
+│   │   └── mac-studio.nix         # AI lab (Ollama native service)
+│   └── linux/
+│       └── home.nix                # Linux user config (OrbStack / Jetson / VPS)
 └── modules/
-    ├── common.nix                     # Shared packages, git config, bash aliases
-    ├── editors/vim.nix                # Neovim configuration
-    └── dev-tools/docker.nix           # Docker tooling (Linux only)
+    ├── common.nix                  # CLI tools + git (all machines)
+    ├── shell/
+    │   └── zsh.nix                 # zsh, starship, aliases, SSH, mackup
+    ├── darwin/
+    │   ├── defaults.nix            # macOS system defaults
+    │   └── homebrew.nix            # Declarative cask management
+    ├── editors/
+    │   └── vim.nix                 # Neovim
+    └── dev-tools/
+        └── docker.nix              # Docker tools (Linux)
 ```
 
-## Adding packages
-
-Edit `modules/common.nix` to add packages available to all configurations:
+## Adding a New App
 
 ```nix
-home.packages = with pkgs; [
-  curl jq git ripgrep fd tree htop
-  # add new packages here
-];
+# modules/darwin/homebrew.nix  → all machines
+casks = [ ... "new-app" ];
+
+# configurations/macos/macbook.nix  → MacBooks only
+homebrew.casks = [ ... "new-app" ];
 ```
 
-Or create a new module file and include it in the relevant configuration in `flake.nix`.
+Then: `nrs`
+
+## Manual Exceptions
+
+These cannot be automated (licensing or no cask available):
+- **Adobe Creative Cloud** — license-managed, install manually
+- **IBKR Desktop** — download from ibkr.com
+- **StarMoney / Finanzguru / Bank X** — German banking apps, no casks
+- **Mac App Store apps** — use `mas install <id>` or install manually
+
+## Update Dependencies
+
+```bash
+nix flake update ~/dotfiles   # nfu alias
+nrs                            # apply updated inputs
+```
+
+## Garbage Collection
+
+Auto-runs weekly (Sunday 3am, keeps 30 days of generations).
+Manual: `ngc`
+
+## Linux / OrbStack VM
+
+```bash
+# Apply on Linux
+nix run home-manager -- switch --flake .#linux -b backup
+```

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# bootstrap.sh — Run once on a fresh Mac
+# Usage: bash <(curl -fsSL https://raw.githubusercontent.com/rh7/dotfiles/main/bootstrap.sh)
+set -e
+
+echo "🚀 Starting Mac bootstrap..."
+
+# ── 1. Xcode CLI Tools ────────────────────────────────────────────────────
+if ! xcode-select -p &>/dev/null; then
+  echo "→ Installing Xcode CLI tools..."
+  xcode-select --install
+  echo "  Wait for install to complete, then re-run this script."
+  exit 0
+fi
+
+# ── 2. Nix (Determinate Systems — handles Apple Silicon quirks) ───────────
+if ! command -v nix &>/dev/null; then
+  echo "→ Installing Nix..."
+  curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
+    | sh -s -- install --no-confirm
+  . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+fi
+
+# ── 3. Clone dotfiles ─────────────────────────────────────────────────────
+DOTFILES="$HOME/dotfiles"
+if [ ! -d "$DOTFILES" ]; then
+  echo "→ Cloning dotfiles..."
+  git clone https://github.com/rh7/dotfiles.git "$DOTFILES"
+else
+  echo "→ dotfiles already present, pulling latest..."
+  git -C "$DOTFILES" pull
+fi
+
+# ── 4. Apply nix-darwin config ────────────────────────────────────────────
+HOSTNAME=$(hostname -s)
+echo "→ Applying nix-darwin for: $HOSTNAME"
+cd "$DOTFILES"
+
+if ! command -v darwin-rebuild &>/dev/null; then
+  echo "→ Bootstrapping nix-darwin..."
+  nix run nix-darwin -- switch --flake ".#$HOSTNAME"
+else
+  darwin-rebuild switch --flake ".#$HOSTNAME"
+fi
+
+# ── 5. mackup restore (restores app settings from iCloud) ─────────────────
+echo ""
+echo "✅ Bootstrap complete!"
+echo ""
+echo "Next steps:"
+echo "  1. Sign into iCloud and wait for mackup folder to sync"
+echo "  2. Run: mackup restore"
+echo "  3. Sign into 1Password → enable SSH Agent"
+echo "  4. Sign into Arc (browser sync)"
+echo "  5. Sign into Cursor (GitHub settings sync)"
+echo ""
+echo "To apply config changes in future: nrs"

--- a/configurations/macos/home.nix
+++ b/configurations/macos/home.nix
@@ -1,8 +1,47 @@
 { pkgs, ... }:
 
 {
-  home.username = "rouvenheck";
+  home.username     = "rouvenheck";
   home.homeDirectory = "/Users/rouvenheck";
-  home.stateVersion = "24.11";
+  home.stateVersion  = "24.11";
   programs.home-manager.enable = true;
+
+  # ── Dev toolchains (Nix-managed — no more manual installs) ───────────────
+  home.packages = with pkgs; [
+    # Node
+    nodejs_22
+
+    # Python
+    python312
+    uv              # fast pip replacement, use instead of pip directly
+
+    # Rust
+    rustup
+
+    # Claude Code
+    nodePackages."@anthropic-ai/claude-code"
+
+    # Railway CLI
+    nodePackages."@railway/cli"
+
+    # Supabase CLI
+    supabase-cli
+
+    # Other dev tools
+    git-lfs
+    pre-commit
+  ];
+
+  # ── Zed editor config ─────────────────────────────────────────────────────
+  home.file.".config/zed/settings.json".text = builtins.toJSON {
+    ui_font_size     = 14;
+    buffer_font_family = "JetBrainsMono Nerd Font";
+    buffer_font_size = 13;
+    theme            = "One Dark";
+    tab_size         = 2;
+    format_on_save   = "on";
+    autosave         = { after_delay = { milliseconds = 1000; }; };
+    terminal.font_family = "JetBrainsMono Nerd Font";
+    vim_mode         = false;
+  };
 }

--- a/configurations/macos/mac-mini-office.nix
+++ b/configurations/macos/mac-mini-office.nix
@@ -1,0 +1,11 @@
+{ ... }:
+
+{
+  # ── Office Mac Mini — smart home hub + desktop ───────────────────────────
+  homebrew.casks = [
+    "home-assistant"
+    "homey"
+    "microsoft-office"
+    "libreoffice"
+  ];
+}

--- a/configurations/macos/mac-studio.nix
+++ b/configurations/macos/mac-studio.nix
@@ -1,0 +1,24 @@
+{ ... }:
+
+{
+  # ── Mac Studio — AI inference lab ────────────────────────────────────────
+  # Ollama must run natively for Metal/ANE GPU access — cannot be in a VM
+  homebrew.brews = [ "ollama" ];
+  homebrew.casks = [ "lm-studio" ];
+
+  # Ollama as a managed launchd service
+  launchd.user.agents.ollama = {
+    serviceConfig = {
+      Label           = "com.ollama.ollama";
+      ProgramArguments = [ "/opt/homebrew/bin/ollama" "serve" ];
+      RunAtLoad       = true;
+      KeepAlive       = true;
+      StandardOutPath = "/tmp/ollama.log";
+      StandardErrorPath = "/tmp/ollama.error.log";
+      EnvironmentVariables = {
+        OLLAMA_HOST   = "0.0.0.0:11434";
+        OLLAMA_MODELS = "/Users/rouvenheck/.ollama/models";
+      };
+    };
+  };
+}

--- a/configurations/macos/macbook.nix
+++ b/configurations/macos/macbook.nix
@@ -1,0 +1,31 @@
+{ ... }:
+
+{
+  # ── MacBook-specific Homebrew casks ──────────────────────────────────────
+  homebrew.casks = [
+    # Writing (until fully migrated to Obsidian)
+    "ulysses"
+
+    # Finance — Germany
+    "quicken"
+
+    # Crypto / trading
+    "electrum"
+    "exodus"
+
+    # Dev extras
+    "pgadmin4"
+
+    # Personal
+    "vlc"
+    "remarkable"
+    "headway"
+
+    # Note: Adobe CC — install manually (license-managed, no cask)
+    # Note: IBKR Desktop — install from ibkr.com
+    # Note: StarMoney, Finanzguru, Bank X — no casks available
+  ];
+
+  # ── Slightly smaller dock on laptop screens ───────────────────────────────
+  system.defaults.dock.tilesize = 40;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,55 +1,93 @@
 {
-  description = "My universal Nix setup for Mac and Linux";
+  description = "Rouven's universal Nix setup for Mac and Linux";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nix-darwin = {
+      url = "github:LnL7/nix-darwin";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 
-  outputs = { self, nixpkgs, home-manager }:
-    let
-      # Helper to build a home configuration for a given system
-      mkHome = { system, modules }:
-        home-manager.lib.homeManagerConfiguration {
-          pkgs = import nixpkgs { inherit system; };
-          modules = modules;
-        };
-    in {
-      homeConfigurations = {
-        # Mac (Apple Silicon)
-        mac = mkHome {
-          system = "aarch64-darwin";
-          modules = [
-            ./configurations/macos/home.nix
-            ./modules/common.nix
-            ./modules/editors/vim.nix
-          ];
-        };
-
-        # Linux (ARM64 — OrbStack VM / Docker)
-        linux = mkHome {
-          system = "aarch64-linux";
-          modules = [
-            ./configurations/linux/home.nix
-            ./modules/common.nix
-            ./modules/editors/vim.nix
-            ./modules/dev-tools/docker.nix
-          ];
-        };
+  outputs = { self, nixpkgs, nix-darwin, home-manager, ... }:
+  let
+    # ── Helper: full macOS system config (nix-darwin + home-manager) ─────────
+    mkMac = { hostname, extraModules ? [] }:
+      nix-darwin.lib.darwinSystem {
+        system = "aarch64-darwin";
+        modules = [
+          ./modules/common.nix
+          ./modules/darwin/defaults.nix
+          ./modules/darwin/homebrew.nix
+          home-manager.darwinModules.home-manager
+          {
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+            home-manager.users.rouvenheck = import ./configurations/macos/home.nix;
+            networking.hostName = hostname;
+            networking.computerName = hostname;
+          }
+        ] ++ extraModules;
       };
 
-      # Dev shell for working on the dotfiles themselves
-      devShells = builtins.listToAttrs (map (system: {
-        name = system;
-        value = {
-          default = let pkgs = import nixpkgs { inherit system; }; in
-            pkgs.mkShell {
-              packages = with pkgs; [ git curl jq ];
-            };
-        };
-      }) [ "aarch64-linux" "aarch64-darwin" "x86_64-linux" ]);
+    # ── Helper: Linux home-manager only (OrbStack VM / Jetson / servers) ─────
+    mkLinux = { system ? "aarch64-linux", modules ? [] }:
+      home-manager.lib.homeManagerConfiguration {
+        pkgs = import nixpkgs { inherit system; };
+        modules = [
+          ./configurations/linux/home.nix
+          ./modules/common.nix
+          ./modules/editors/vim.nix
+          ./modules/dev-tools/docker.nix
+        ] ++ modules;
+      };
+  in {
+
+    # ── macOS machines ────────────────────────────────────────────────────────
+    darwinConfigurations = {
+      "m5-air" = mkMac {
+        hostname = "m5-air";
+        extraModules = [ ./configurations/macos/macbook.nix ];
+      };
+      "rouven-air-m3" = mkMac {
+        hostname = "rouven-air-m3";
+        extraModules = [ ./configurations/macos/macbook.nix ];
+      };
+      "rouven-pro-m4" = mkMac {
+        hostname = "rouven-pro-m4";
+        extraModules = [ ./configurations/macos/macbook.nix ];
+      };
+      "rouvens-mac-mini" = mkMac {
+        hostname = "rouvens-mac-mini";
+        extraModules = [ ./configurations/macos/mac-mini-office.nix ];
+      };
+      "rouvens-mac-studio" = mkMac {
+        hostname = "rouvens-mac-studio";
+        extraModules = [ ./configurations/macos/mac-studio.nix ];
+      };
     };
+
+    # ── Linux configs ─────────────────────────────────────────────────────────
+    homeConfigurations = {
+      # OrbStack NixOS VM (aarch64)
+      "linux" = mkLinux { system = "aarch64-linux"; };
+      # Jetson AGX Orin
+      "jetson" = mkLinux { system = "aarch64-linux"; };
+      # Contabo VPS (x86)
+      "contabo" = mkLinux { system = "x86_64-linux"; };
+    };
+
+    # ── Dev shell for working on dotfiles ─────────────────────────────────────
+    devShells = builtins.listToAttrs (map (system: {
+      name = system;
+      value.default = let pkgs = import nixpkgs { inherit system; }; in
+        pkgs.mkShell {
+          packages = with pkgs; [ git curl nixpkgs-fmt nil ];
+        };
+    }) [ "aarch64-linux" "aarch64-darwin" "x86_64-linux" ]);
+  };
 }

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -1,32 +1,57 @@
 { pkgs, ... }:
 
 {
+  # ── CLI tools available on every machine ─────────────────────────────────
   home.packages = with pkgs; [
+    # Core utils
     curl
+    wget
     jq
+    yq
     git
-    ripgrep
-    fd
-    tree
+    gh           # GitHub CLI
+    ripgrep      # better grep
+    fd           # better find
+    bat          # better cat
+    eza          # better ls
+    fzf          # fuzzy finder
+    zoxide       # smarter cd
     htop
+    bottom       # better htop
+    tldr
+    tree
+
+    # Dev
+    gnupg
+    mkcert
+    nixpkgs-fmt  # Nix formatter
+    nil          # Nix LSP
+
+    # Network
+    nmap
   ];
 
+  # ── Git ──────────────────────────────────────────────────────────────────
   programs.git = {
     enable = true;
-    settings = {
-      user.name = "Pip";
-      user.email = "rpip@fastmail.com";
+    userName = "Rouven Heck";
+    userEmail = "rouven@fidenexum.com";
+    extraConfig = {
       init.defaultBranch = "main";
       pull.rebase = true;
+      push.autoSetupRemote = true;
+      core.editor = "zed --wait";
     };
+    ignores = [
+      ".DS_Store"
+      ".env"
+      ".env.local"
+      "*.local"
+      ".direnv"
+      ".claude"
+    ];
   };
 
-  programs.bash = {
-    enable = true;
-    shellAliases = {
-      ll = "ls -la";
-      gs = "git status";
-      gd = "git diff";
-    };
-  };
+  # ── Shell — import from shell module ─────────────────────────────────────
+  imports = [ ../modules/shell/zsh.nix ];
 }

--- a/modules/darwin/defaults.nix
+++ b/modules/darwin/defaults.nix
@@ -1,0 +1,54 @@
+{ ... }:
+
+{
+  # ── macOS system defaults ─────────────────────────────────────────────────
+  system.defaults = {
+    dock = {
+      autohide                  = true;
+      autohide-delay            = 0.0;
+      autohide-time-modifier    = 0.2;
+      show-recents              = false;
+      minimize-to-application   = true;
+      tilesize                  = 48;
+    };
+    finder = {
+      AppleShowAllFiles         = true;
+      ShowPathbar               = true;
+      ShowStatusBar             = true;
+      FXPreferredViewStyle      = "Nlsv"; # list view
+      FXDefaultSearchScope      = "SCcf"; # search current folder
+      _FXShowPosixPathInTitle   = true;
+    };
+    trackpad = {
+      Clicking                  = true;  # tap to click
+      TrackpadThreeFingerDrag   = true;
+    };
+    keyboard = {
+      KeyRepeat                 = 2;
+      InitialKeyRepeat          = 15;
+    };
+    screensaver = {
+      askForPassword            = true;
+      askForPasswordDelay       = 5;
+    };
+    NSGlobalDomain = {
+      AppleInterfaceStyle                   = "Dark";
+      AppleShowAllExtensions                = true;
+      NSAutomaticSpellingCorrectionEnabled  = false;
+      NSAutomaticCapitalizationEnabled      = false;
+      NSAutomaticDashSubstitutionEnabled    = false;
+      NSAutomaticQuoteSubstitutionEnabled   = false;
+      "com.apple.swipescrolldirection"      = false; # disable natural scroll
+    };
+    CustomUserPreferences = {
+      "com.apple.screencapture" = {
+        location        = "~/Screenshots";
+        type            = "png";
+        disable-shadow  = true;
+      };
+    };
+  };
+
+  system.stateVersion = 5;
+  nixpkgs.hostPlatform = "aarch64-darwin";
+}

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -1,0 +1,88 @@
+{ ... }:
+
+{
+  # ── Homebrew — declarative cask management ───────────────────────────────
+  # nix-darwin drives Homebrew; anything NOT listed here gets removed on `nrs`
+  homebrew = {
+    enable = true;
+    onActivation = {
+      autoUpdate  = true;
+      upgrade     = true;
+      cleanup     = "zap";  # removes unlisted casks/brews
+    };
+
+    taps = [
+      "homebrew/bundle"
+    ];
+
+    # ── Installed on every machine ───────────────────────────────────────
+    casks = [
+      # Security
+      "1password"
+
+      # Browsers
+      "arc"
+
+      # Productivity
+      "raycast"
+      "obsidian"
+      "notion"
+      "linear-linear"
+      "granola"
+      "superwhisper"
+      "superhuman"
+      "clockify"
+
+      # Communication
+      "telegram"
+      "slack"
+      "signal"
+      "franz"          # multi-account WhatsApp
+      "discord"
+      "zoom"
+
+      # Dev
+      "cursor"
+      "zed"
+      "wezterm"
+      "termius"
+      "docker"
+      "orbstack"
+
+      # Storage & sync
+      "dropbox"
+
+      # Finance / crypto
+      "ledger-live"
+      "crypto-pro"
+
+      # VPN / security
+      "expressvpn"
+      "wireguard"
+      "gpg-suite"
+
+      # AI
+      "claude"
+      "chatgpt"
+
+      # Media
+      "spotify"
+      "pocket-casts"
+      "endel"
+
+      # Utilities
+      "tailscale"
+      "tripmode"
+
+      # Fonts
+      "font-jetbrains-mono-nerd-font"
+      "font-inter"
+    ];
+
+    # ── CLI tools better managed via Homebrew than Nix on macOS ─────────
+    brews = [
+      "mas"      # Mac App Store CLI
+      "mackup"   # App settings sync
+    ];
+  };
+}

--- a/modules/shell/zsh.nix
+++ b/modules/shell/zsh.nix
@@ -1,0 +1,140 @@
+{ pkgs, ... }:
+
+{
+  programs.zsh = {
+    enable = true;
+    autosuggestions.enable = true;
+    syntaxHighlighting.enable = true;
+
+    shellAliases = {
+      # Better defaults
+      ll    = "eza -la --git";
+      ls    = "eza";
+      cat   = "bat";
+      cd    = "z";       # zoxide
+      ".."  = "cd ..";
+      "..." = "cd ../..";
+
+      # Git
+      gs  = "git status";
+      ga  = "git add";
+      gc  = "git commit";
+      gp  = "git push";
+      gl  = "git log --oneline -20";
+      gd  = "git diff";
+      gco = "git checkout";
+      gbr = "git branch";
+
+      # Nix / nix-darwin
+      nrs  = "darwin-rebuild switch --flake ~/dotfiles";
+      nrb  = "darwin-rebuild build --flake ~/dotfiles";
+      nfu  = "nix flake update ~/dotfiles";
+      ngc  = "nix-collect-garbage -d";
+      nfmt = "nixpkgs-fmt ~/dotfiles/**/*.nix";
+
+      # Docker / OrbStack
+      d   = "docker";
+      dc  = "docker compose";
+      dps = "docker ps";
+      dex = "docker exec -it";
+
+      # Tailscale
+      ts  = "tailscale";
+      tss = "tailscale status";
+    };
+
+    initExtra = ''
+      # zoxide (smarter cd)
+      eval "$(zoxide init zsh)"
+
+      # fzf
+      eval "$(fzf --zsh)"
+
+      # 1Password SSH Agent
+      export SSH_AUTH_SOCK=~/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agent.sock
+
+      # Homebrew (Apple Silicon path)
+      eval "$(/opt/homebrew/bin/brew shellenv)"
+
+      # Local scripts on PATH
+      export PATH="$HOME/.local/bin:$PATH"
+
+      # uv — fast Python package manager
+      export UV_PYTHON_PREFERENCE=managed
+    '';
+  };
+
+  # ── Starship prompt ───────────────────────────────────────────────────────
+  programs.starship = {
+    enable = true;
+    settings = {
+      format = "$directory$git_branch$git_status$nodejs$python$rust$nix_shell$cmd_duration$line_break$character";
+      directory.truncation_length = 3;
+      git_branch.symbol  = " ";
+      nodejs.symbol      = " ";
+      python.symbol      = " ";
+      rust.symbol        = " ";
+      nix_shell.symbol   = "❄️ ";
+      cmd_duration = {
+        min_time = 2000;
+        format   = "took [$duration]($style) ";
+      };
+    };
+  };
+
+  # ── SSH ──────────────────────────────────────────────────────────────────
+  programs.ssh = {
+    enable = true;
+    extraConfig = ''
+      # 1Password SSH agent — handles all keys
+      Host *
+        IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+        ServerAliveInterval 60
+        ServerAliveCountMax 3
+
+      # Tailscale hostnames
+      Host mac-studio
+        HostName rouvens-mac-studio
+        User rouvenheck
+
+      Host mac-mini
+        HostName rouvens-mac-mini
+        User rouvenheck
+
+      Host jetson
+        HostName jetson-rorin2
+        User rouvenheck
+
+      Host contabo
+        HostName contabo-vps-rh7lab
+        User root
+    '';
+  };
+
+  # ── mackup (app settings sync via iCloud) ────────────────────────────────
+  # To migrate to Dropbox: change engine to "dropbox" then run: mackup backup
+  #
+  # Only apps with mackup support listed here.
+  # Unsupported (sync via their own account/iCloud): raycast, obsidian, slack, superhuman, clockify
+  home.file.".mackup.cfg".text = ''
+    [storage]
+    engine = icloud
+    directory = mackup
+
+    [applications_to_sync]
+    cursor
+    zed
+    terminal
+    ssh
+    git
+    zsh
+    telegram_macos
+    franz
+    spotify
+    wezterm
+    starship
+    gnupg
+    claude-code
+    tripmode
+  '';
+}


### PR DESCRIPTION
- Add nix-darwin to flake.nix alongside home-manager
- Define all 5 Mac machines + Linux configs (OrbStack, Jetson, Contabo)
- Add modules/darwin/defaults.nix — declarative macOS system defaults
- Add modules/darwin/homebrew.nix — all casks managed declaratively
- Add modules/shell/zsh.nix — zsh, starship prompt, aliases, SSH, mackup
- Add configurations/macos/macbook.nix — MacBook-specific apps
- Add configurations/macos/mac-mini-office.nix — smart home + office apps
- Add configurations/macos/mac-studio.nix — Ollama as native launchd service
- Update common.nix — correct git identity, expanded CLI tools
- Update configurations/macos/home.nix — dev toolchains via Nix (Node, Python, Rust)
- Add bootstrap.sh — one-command fresh Mac setup
- Update README.md — full docs, settings sync strategy, machine table

Settings sync strategy:
  macOS defaults + Homebrew → nix-darwin (nrs) Shell + dotfiles → Home Manager (nrs) App preferences → mackup via iCloud SSH keys → 1Password SSH Agent Secrets → 1Password CLI