### PR TITLE
Add sops-nix for encrypted secret management

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,35 @@
+# sops-nix configuration
+# Each machine has its own age key. Secrets are encrypted for specific hosts.
+#
+# To add a new machine:
+#   1. Generate key on the device: age-keygen -o ~/.config/sops/age/keys.txt
+#   2. Get the public key: age-keygen -y ~/.config/sops/age/keys.txt
+#   3. Add the public key below under the machine's name
+#   4. Re-encrypt secrets: sops updatekeys secrets/secrets.yaml
+#
+# To add a secret:
+#   1. sops secrets/secrets.yaml   (opens in $EDITOR, encrypted at rest)
+#   2. Reference in Nix: sops.secrets."secret-name".owner = "rouvenheck";
+
+keys:
+  # ── Admin key (your primary machine — can decrypt all secrets) ──
+  - &admin age1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+  # ── Per-machine keys (add real public keys as you bootstrap each device) ──
+  # - &m5-air age1...
+  # - &mac-mini age1...
+  # - &mac-studio age1...
+  # - &thinkpad age1...
+  # - &vps-hetzner age1...
+
+creation_rules:
+  # All secrets — encrypted for admin key (add per-machine keys as needed)
+  - path_regex: secrets/secrets\.yaml$
+    key_groups:
+      - age:
+          - *admin
+          # - *m5-air
+          # - *mac-mini
+          # - *mac-studio
+          # - *thinkpad
+          # - *vps-hetzner

--- a/flake.nix
+++ b/flake.nix
@@ -11,9 +11,13 @@
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    sops-nix = {
+      url = "github:Mic92/sops-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, nix-darwin, home-manager, ... }:
+  outputs = { self, nixpkgs, nix-darwin, home-manager, sops-nix, ... }:
   let
     # ── Helper: full macOS system config (nix-darwin + home-manager) ─────────
     # Now accepts a `role` module and optional extra modules.
@@ -31,6 +35,8 @@
           ./modules/darwin/defaults.nix
           ./modules/darwin/homebrew.nix
           role
+          sops-nix.darwinModules.sops
+          ./modules/secrets.nix
           home-manager.darwinModules.home-manager
           {
             home-manager.useGlobalPkgs = true;
@@ -62,6 +68,8 @@
         modules = [
           ./modules/nixos/system.nix
           role
+          sops-nix.nixosModules.sops
+          ./modules/secrets.nix
           home-manager.nixosModules.home-manager
           {
             home-manager.useGlobalPkgs = true;


### PR DESCRIPTION
## Summary
- Add sops-nix flake input for encrypted secrets
- Wire `sops.darwinModules.sops` and `sops.nixosModules.sops` into both helpers
- Create `.sops.yaml` with per-machine age key structure
- Create `modules/secrets.nix` with initial secret declarations (github_token, tailscale_auth_key, catalog_agent_token)
- Create placeholder `secrets/secrets.yaml` (encrypt after generating your age key)

## Setup (on your primary Mac)
```bash
# 1. Generate age key
age-keygen -o ~/.config/sops/age/keys.txt

# 2. Copy the public key, paste into .sops.yaml replacing the placeholder

# 3. Encrypt the secrets file
sops -e -i secrets/secrets.yaml

# 4. Now edit secrets anytime with:
sops secrets/secrets.yaml
```

## Test plan
- [ ] `nix flake check` passes
- [ ] Verify sops-nix module loads on darwin-rebuild
- [ ] Generate age key and encrypt secrets file
- [ ] Confirm secrets are decrypted at /etc/sops-nix/secrets/ after rebuild

Closes rh7/rh-device-management#5

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>