### PR TITLE
Fix rh-device-management#45: nuclear cleanup fallback for uninstall-nix.sh

### DIFF
--- a/scripts/uninstall-nix.sh
+++ b/scripts/uninstall-nix.sh
@@ -3,6 +3,9 @@
 # After this, reboot and run: curl -fsSL config.rh7labs.com/setup | bash
 #
 # Usage: curl -fsSL https://raw.githubusercontent.com/rh7/dotfiles/main/scripts/uninstall-nix.sh | bash
+#
+# Flags:
+#   --force-nuclear   Skip the standard uninstaller and go straight to manual cleanup
 
 set -euo pipefail
 
@@ -18,6 +21,61 @@ ok()    { echo -e "${GREEN}[OK]${NC}    $*"; }
 warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
 err()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 
+FORCE_NUCLEAR=false
+for arg in "$@"; do
+  case "$arg" in
+    --force-nuclear) FORCE_NUCLEAR=true ;;
+  esac
+done
+
+# Manual nuclear cleanup. Used as a fallback when nix-installer refuses to
+# uninstall (Determinate v3.17+ checks for darwin-rebuild in the Nix store
+# and fails repeatedly even after artifacts are removed). Proven on m5-air
+# 2026-04-07. Reboot required afterward.
+nuclear_cleanup() {
+  local os
+  os="$(uname -s)"
+  warn "Performing manual nuclear cleanup. This will:"
+  warn "  - Stop and remove nix-daemon launchd services"
+  warn "  - Delete /nix and the Nix APFS volume"
+  warn "  - Remove /etc/nix, /etc/static, /etc/profiles, /etc/*.before-nix-darwin"
+  warn "  - Delete _nixbld1..32 users and the nixbld group"
+  warn "  - Require a reboot"
+  echo ""
+  if [[ -t 0 ]]; then
+    echo -en "${BOLD}  Continue with nuclear cleanup? [y/N] ${NC}"
+    read -r confirm < /dev/tty
+    [[ "$confirm" != "y" && "$confirm" != "Y" ]] && { info "Cancelled."; exit 0; }
+  else
+    warn "Non-interactive run — proceeding without confirmation"
+  fi
+
+  info "Stopping nix-daemon launchd services..."
+  sudo launchctl bootout system/systems.determinate.nix-daemon 2>/dev/null || true
+  sudo launchctl bootout system/org.nixos.nix-daemon 2>/dev/null || true
+  sudo rm -f /Library/LaunchDaemons/*nix* /Library/LaunchDaemons/*determinate* 2>/dev/null || true
+
+  if [[ "$os" == "Darwin" ]]; then
+    info "Removing Nix APFS volume..."
+    sudo diskutil apfs deleteVolume /nix 2>/dev/null || true
+  fi
+
+  info "Removing /etc Nix artifacts..."
+  sudo rm -rf /etc/nix /etc/static /etc/profiles 2>/dev/null || true
+  sudo rm -f /etc/*.before-nix-darwin 2>/dev/null || true
+
+  info "Removing nixbld users and group..."
+  for i in $(seq 1 32); do
+    sudo dscl . -delete /Users/_nixbld$i 2>/dev/null || true
+  done
+  sudo dscl . -delete /Groups/nixbld 2>/dev/null || true
+
+  info "Removing /nix..."
+  sudo rm -rf /nix 2>/dev/null || true
+
+  ok "Nuclear cleanup complete. Reboot required: sudo reboot"
+}
+
 echo ""
 echo -e "${BOLD}━━━ Nix Uninstall ━━━${NC}"
 echo ""
@@ -25,6 +83,18 @@ echo ""
 # ── Check if Nix is installed ──
 if ! command -v nix &>/dev/null && [[ ! -d /nix ]]; then
   ok "Nix is not installed. Nothing to do."
+  exit 0
+fi
+
+# ── Force-nuclear shortcut ──
+if $FORCE_NUCLEAR; then
+  warn "--force-nuclear specified — skipping nix-installer uninstall"
+  nuclear_cleanup
+  echo ""
+  echo -e "${BOLD}Next steps:${NC}"
+  echo "  1. Reboot:  sudo reboot"
+  echo "  2. Reinstall:  curl -fsSL https://raw.githubusercontent.com/rh7/dotfiles/main/scripts/setup.sh | bash"
+  echo ""
   exit 0
 fi
 
@@ -56,16 +126,30 @@ else
 fi
 
 # ── Step 2: Uninstall Nix ──
+INSTALLER_OK=false
 if [[ -x /nix/nix-installer ]]; then
-  info "Uninstalling Nix via nix-installer..."
-  /nix/nix-installer uninstall
+  info "Uninstalling Nix via /nix/nix-installer..."
+  if /nix/nix-installer uninstall; then
+    INSTALLER_OK=true
+  else
+    warn "/nix/nix-installer uninstall failed (Determinate v3.17+ stubbornly detects nix-darwin)"
+  fi
 elif command -v nix-installer &>/dev/null; then
   info "Uninstalling Nix via nix-installer..."
-  nix-installer uninstall
+  if nix-installer uninstall; then
+    INSTALLER_OK=true
+  else
+    warn "nix-installer uninstall failed"
+  fi
 else
-  warn "No nix-installer found. You may need to uninstall manually."
-  warn "See: https://nix.dev/manual/nix/stable/installation/uninstall"
-  exit 1
+  warn "No nix-installer found."
+fi
+
+if ! $INSTALLER_OK; then
+  echo ""
+  warn "Standard uninstaller could not complete. Falling back to nuclear cleanup."
+  echo ""
+  nuclear_cleanup
 fi
 
 # ── Step 3: Clean up remnants ──


### PR DESCRIPTION
## Summary

`uninstall-nix.sh` relied on `/nix/nix-installer uninstall` and exited if it failed. Determinate v3.17+ stubbornly detects nix-darwin and refuses to uninstall even after every documented artifact is removed. Discovered during the m5-air migration session on 2026-04-07 — had to fall back to manual nuclear cleanup.

## Changes

- New `nuclear_cleanup` function with the proven manual sequence: launchctl bootout, APFS volume delete, /etc cleanup, nixbld user/group removal, /nix removal
- `nuclear_cleanup` runs automatically when `nix-installer uninstall` returns non-zero
- New `--force-nuclear` flag to skip the standard path entirely
- User is prompted before nuclear cleanup (unless stdin is not a tty)
- Reboot is required after nuclear cleanup; the script says so

## Testing

- `bash -n scripts/uninstall-nix.sh` passes
- The nuclear sequence is byte-for-byte the one proven to work in the issue body

Fixes rh7/rh-device-management#45

---
*Auto-generated by `/fix-all` workflow*