### PR TITLE
Fix rh-device-management#50: stop trying to install masApps from brew bundle

### DIFF
--- a/modules/darwin/profiles/core.nix
+++ b/modules/darwin/profiles/core.nix
@@ -17,12 +17,16 @@
   ];
 
   homebrew.brews = [
-    "mas"        # Mac App Store CLI
+    "mas"        # Mac App Store CLI (kept for manual use)
     "mackup"     # settings sync
   ];
 
-  homebrew.masApps = {
-    "Perplexity" = 6714467650;
-    "Endel" = 1346247457;
-  };
+  # masApps disabled — `mas` install fails non-interactively on modern macOS,
+  # which breaks the entire `darwin-rebuild switch` brew bundle phase.
+  # Tracked as App Store manual installs in the post-setup checklist instead.
+  # See rh7/rh-device-management#50.
+  # homebrew.masApps = {
+  #   "Perplexity" = 6714467650;
+  #   "Endel" = 1346247457;
+  # };
 }

--- a/modules/darwin/profiles/finance.nix
+++ b/modules/darwin/profiles/finance.nix
@@ -7,7 +7,9 @@
     # finanzguru, starmoney — Mac App Store only
   ];
 
-  homebrew.masApps = {
-    "Crypto Pro" = 980888073;
-  };
+  # masApps disabled — see rh7/rh-device-management#50.
+  # Crypto Pro is now a manual App Store install per the post-setup checklist.
+  # homebrew.masApps = {
+  #   "Crypto Pro" = 980888073;
+  # };
 }


### PR DESCRIPTION
## Summary

`mas` CLI fails non-interactively on modern macOS, breaking the entire `brew bundle` phase of `darwin-rebuild switch` whenever a fresh Mac tries to install an App Store app it doesn't already have cached. Discovered helping Kassie complete her first rebuild — Streaks killed the bundle.

The productivity profile was already patched in commit 7ad425a, but `core.nix` (Perplexity, Endel — every Mac) and `finance.nix` (Crypto Pro) hit the exact same failure on any fresh install. They only "worked" before because the apps were already installed manually.

## Changes

- Comment out `homebrew.masApps` in `modules/darwin/profiles/core.nix`
- Comment out `homebrew.masApps` in `modules/darwin/profiles/finance.nix`
- Cross-reference the issue in both blocks so the next person knows why

App Store apps now follow the same model as `dia`/`speedtest`/`coldRead` — manual install steps in the post-setup checklist (paired PR in rh-device-management).

## Testing

- `nix-instantiate --parse` passes for both modified files
- The `mas` brew is left in place since it's still useful for manual `mas install` runs

Refs rh7/rh-device-management#50

---
*Auto-generated by `/fix-all` workflow*