### PR TITLE
fix(audit): preserve device role on re-register (rh-device-management#60)

### DIFF
--- a/scripts/audit-device.sh
+++ b/scripts/audit-device.sh
@@ -1615,6 +1615,15 @@ AUDIT_DATA
 )
 
 # ── Device registration (replaces heartbeat.sh) ───────────────────────
+# Read this device's currently-assigned role from the config service.
+# Echoes the role, or empty string if the device isn't registered yet /
+# the service is unreachable (callers decide the default).
+fetch_device_role() {
+  local config_url="$1"
+  curl -sf "${config_url}/api/devices/${HOSTNAME}" --max-time 5 2>/dev/null \
+    | python3 -c "import json,sys; print(json.load(sys.stdin).get('role','') or '')" 2>/dev/null
+}
+
 register_device() {
   local config_url="$1"
   local ts_ip="" ssh_pub="" age_pub="" uptime_str="" nix_ver="" nix_gen=""
@@ -1637,13 +1646,20 @@ register_device() {
     age_pub=$(age-keygen -y "$HOME/.config/sops/age/keys.txt" 2>/dev/null || echo "")
   fi
 
+  # Preserve an already-assigned role — the audit script is an inventory
+  # reporter, not the role authority, so it must not reset role on every run.
+  # Default to "workstation" only for a brand-new (never-registered) device.
+  local role
+  role=$(fetch_device_role "$config_url")
+  [[ -z "$role" ]] && role="workstation"
+
   curl -sf -X POST "${config_url}/api/devices/register" \
     -H "Content-Type: application/json" \
     -d "{
       \"hostname\": \"$HOSTNAME\",
       \"os\": \"$OS\",
       \"arch\": \"$ARCH\",
-      \"role\": \"workstation\",
+      \"role\": \"$role\",
       \"tailscale_ip\": \"$ts_ip\",
       \"nix_version\": \"$nix_ver\",
       \"nix_generation\": \"$nix_gen\",
@@ -1656,8 +1672,7 @@ register_device() {
 show_checklist() {
   local config_url="$1"
   local role
-  role=$(curl -sf "${config_url}/api/devices/${HOSTNAME}" --max-time 5 2>/dev/null \
-    | python3 -c "import json,sys; print(json.load(sys.stdin).get('role','workstation'))" 2>/dev/null)
+  role=$(fetch_device_role "$config_url")
   [[ -z "$role" ]] && role="workstation"
 
   local checklist


### PR DESCRIPTION
## Summary
`register_device()` sent `"role": "workstation"` hardcoded in every audit register payload, so each daily audit **clobbered** the device's role on the config service. Kassie's `personal-mac` host reverted to `workstation` after every run, and the fleet apps dashboard + post-setup checklists (which key off role) saw the wrong role.

## Fix
- Add a shared `fetch_device_role` helper that reads the device's current role from `GET /api/devices/:hostname` (empty if never registered / service unreachable).
- `register_device` now resolves the existing role and sends **that**, defaulting to `workstation` only for a brand-new device. The audit script is an inventory reporter, not the role authority — it no longer resets a role it didn't set.
- DRY: `show_checklist` reused the same server-role read inline; it now calls the helper too.

## Verification (against the live config service)
- `bash -n` clean.
- Real extracted `fetch_device_role`: `jetson-rorin2`→`ai-lab`, `GL-AXT1800`→`server`, unknown host→empty (→ defaults `workstation`).
- **End-to-end**: seeded a throwaway device as `personal-mac` → the fixed register path resolved `personal-mac` and re-registered → role stayed `personal-mac` (would have become `workstation` before). Test device deleted (404 after).

This satisfies the acceptance criteria: a `personal-mac` host stays `personal-mac` after `--run`, and a first-time register defaults to `workstation`.

## Notes
- Closes the code bug in **rh7/rh-device-management#60** (cross-repo, so it won't auto-close — will close manually on merge).
- Residual: if the pre-register role GET fails transiently while the POST succeeds, a device could still default to `workstation`. Narrow (same service backs both calls). A fully race-free version is server-side preserve-on-omit (drop `role` from the payload; `POST /api/devices/register` keeps the existing role when none is supplied) — noted as a follow-up.
- The fix prevents future clobbering; it does not retroactively re-assign roles already reset (e.g. `kassie-m5-air13` currently reads `workstation` and needs a one-time correction to `personal-mac`).
- Adjacent same-file issues still open: rh7/rh-device-management#61 (register_device hang on stuck `tailscale` subprocess), rh7/rh-device-management#62 (hostname lowercasing).

Refs rh7/rh-device-management#60
