### PR TITLE
fix(collector-runner): gate on manifest ref/branch/dirty (#99)

### DIFF
--- a/scripts/collector-runner.sh
+++ b/scripts/collector-runner.sh
@@ -63,6 +63,34 @@ fetch_and_verify() {  # writes $CACHE on success
   clean="$(printf '%s' "$manifest" | json_field 'str(d.get("read_only_scan",{}).get("clean",False)).lower()')"
   [ -n "$want" ] || { log "manifest missing sha256"; return 1; }
   if [ "$clean" != "true" ]; then log "REFUSING: $COLLECTOR failed the server read-only scan"; return 3; fi
+
+  # Defense-in-depth (rh-device-management#99, follow-up to #96): consult the
+  # manifest's serving-ref + host-checkout-state fields. Serving is already
+  # pinned to origin/main SERVER-side, so these are belt-and-suspenders:
+  #   - REFUSE if the server is serving from an unexpected ref (guards a
+  #     misconfigured COLLECTOR_REF on the host). Configurable via
+  #     COLLECTOR_EXPECTED_REF (default origin/main); set it empty to disable.
+  #   - WARN (but proceed) if the host's dotfiles checkout is dirty or off-main
+  #     — operator visibility only; the served bytes are still the pinned ref.
+  #   - Tolerate older servers that omit ref/branch/dirty (warn-only, no fail).
+  local ref branch dirty expected="${COLLECTOR_EXPECTED_REF-origin/main}"
+  ref="$(printf '%s' "$manifest" | json_field 'd.get("ref","")')"
+  branch="$(printf '%s' "$manifest" | json_field 'd.get("branch","")')"
+  dirty="$(printf '%s' "$manifest" | json_field 'str(d.get("dirty","")).lower()')"
+  if [ -n "$expected" ] && [ -n "$ref" ] && [ "$ref" != "$expected" ]; then
+    log "REFUSING: server serves $COLLECTOR from ref '$ref', expected '$expected' (set COLLECTOR_EXPECTED_REF= to disable)"; return 4
+  fi
+  if [ -z "$ref" ] && [ -z "$branch" ] && [ -z "$dirty" ]; then
+    log "note: server manifest omits ref/branch/dirty (older server) — gating on sha256 + scan only"
+  else
+    if [ "$dirty" = "true" ]; then
+      log "WARNING: host dotfiles checkout is dirty — served bytes are still pinned ${ref:-origin/main}, proceeding"
+    fi
+    if [ -n "$branch" ] && [ "$branch" != "main" ]; then
+      log "WARNING: host dotfiles checkout is on branch '$branch' (not main) — served bytes are still pinned ${ref:-origin/main}, proceeding"
+    fi
+  fi
+
   tmp="$(mktemp)"
   curl -fsS --max-time 30 "$base/api/collector/$COLLECTOR" -o "$tmp" || { rm -f "$tmp"; log "script fetch failed"; return 1; }
   got="$(sha_of "$tmp")"


### PR DESCRIPTION
## Summary
Defense-in-depth follow-up to rh-device-management#96 (which moved collector serving to a pinned `git show origin/main:<path>` and exposed `ref`/`branch`/`dirty` in the manifest). The device-side runner now consults those fields at its **existing** validation gate — no extra round-trip.

## Behavior
- **REFUSE** (rc=4) if the server serves the collector from an unexpected ref — guards against a misconfigured `COLLECTOR_REF` on the host. Configurable via `COLLECTOR_EXPECTED_REF` (default `origin/main`); set it empty to disable.
- **WARN but proceed** if the host's dotfiles checkout is dirty or on a non-`main` branch — operator visibility only; the served bytes are still the pinned ref, so this is belt-and-suspenders, not a correctness gate.
- **Tolerate older servers** that omit `ref`/`branch`/`dirty` (warn-only, no hard fail) — a runner update won't break against a not-yet-restarted server.

## Verification
- `bash -n` clean.
- Against the live `/api/collector/audit-device.sh/manifest`: ref-mismatch refuses (rc=4); a dirty host checkout warns and proceeds; clean+main produces no warnings.
- Codex review (`codex review --uncommitted`): no findings.

Closes #99. Follow-up to #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)