### PR TITLE
chore(core): declare 1password-cli cask (#70)

### DIFF
--- a/modules/darwin/profiles/core.nix
+++ b/modules/darwin/profiles/core.nix
@@ -4,6 +4,7 @@
   # ── Core macOS apps (every Mac gets these) ───────────────────────────────
   homebrew.casks = [
     "1password"
+    "1password-cli"   # `op` — used by config-service secret reconciliation (rh-device-management#70)
     "google-chrome"
     "arc"
     "firefox"


### PR DESCRIPTION
## Summary
Adds the 1Password CLI (`op`) to the core managed casks so it's present declaratively on every Mac. Used by the config-service secret-recovery reconciler (rh-device-management#70) to resolve `recovery_path` against the 1Password vault (titles/vaults only, never values). The GUI `1password` cask was already declared; this pins the CLI alongside it.

One-line declarative change (valid cask, already installed on the Studio). Refs #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)