### PR TITLE
fix(audit): hard-timeout register_device shellouts so a wedged tailscale can't hang the audit

### DIFF
--- a/scripts/audit-device.sh
+++ b/scripts/audit-device.sh
@@ -37,6 +37,26 @@ ok()    { echo -e "${GREEN}✓${NC}  $*"; }
 warn()  { echo -e "${YELLOW}⚠${NC}  $*"; }
 err()   { echo -e "${RED}✗${NC}  $*" >&2; }
 
+# run_timeout SECS CMD... — run a command with a hard timeout so a wedged daemon
+# (e.g. a stuck tailscaled, #61) can't hang the audit forever. Prefers coreutils
+# timeout/gtimeout (Linux, nix); falls back to perl (/usr/bin/perl ships on macOS,
+# which has no `timeout`): the parent arms an alarm and SIGKILLs the child on
+# overrun, exiting 124 like GNU timeout; the child execs the command so its stdout
+# passes through for $() capture. On timeout the child is killed and we return
+# non-zero with no output, so callers degrade via their existing `|| echo ""`.
+run_timeout() {
+  local secs="$1"; shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$secs" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$secs" "$@"
+  elif command -v perl >/dev/null 2>&1; then
+    perl -e 'my $s=shift; my $p=fork; if($p){$SIG{ALRM}=sub{kill "KILL",$p; exit 124}; alarm $s; waitpid $p,0; exit($?>>8)} else {exec @ARGV or exit 127}' "$secs" "$@"
+  else
+    "$@"
+  fi
+}
+
 # ── Interactive menu ────────────────────────────────────────────────────
 if [[ "$MODE" == "interactive" ]]; then
   # When piped via curl, read from /dev/tty for interactive input
@@ -2018,14 +2038,14 @@ register_device() {
   local config_url="$1"
   local ts_ip="" ssh_pub="" age_pub="" uptime_str="" nix_ver="" nix_gen=""
 
-  ts_ip=$(tailscale ip -4 2>/dev/null || echo "")
-  nix_ver=$(nix --version 2>/dev/null || echo "")
+  ts_ip=$(run_timeout 5 tailscale ip -4 2>/dev/null || echo "")
+  nix_ver=$(run_timeout 5 nix --version 2>/dev/null || echo "")
   uptime_str=$(uptime | sed 's/.*up //' | sed 's/,.*//')
 
   if [[ "$OS" == "Darwin" ]]; then
-    nix_gen=$(darwin-rebuild --list-generations 2>/dev/null | tail -1 | awk '{print $1}' || echo "")
+    nix_gen=$(run_timeout 10 darwin-rebuild --list-generations 2>/dev/null | tail -1 | awk '{print $1}' || echo "")
   else
-    nix_gen=$(nixos-rebuild list-generations 2>/dev/null | tail -1 | awk '{print $1}' || echo "")
+    nix_gen=$(run_timeout 10 nixos-rebuild list-generations 2>/dev/null | tail -1 | awk '{print $1}' || echo "")
   fi
 
   for keyfile in "$HOME/.ssh/id_ed25519.pub" "$HOME/.ssh/id_rsa.pub"; do


### PR DESCRIPTION
## Summary
`register_device` in `scripts/audit-device.sh` shelled out to `tailscale ip -4` (and `nix --version`, `darwin-rebuild`/`nixos-rebuild list-generations`) with **no timeout**. On 2026-04-10 a stuck `tailscaled` child left the audit blocked **17+ minutes** after a successful upload, and LaunchAgent/cron firings then piled up zombie bash processes — a silent failure where `last_seen` updated (upload runs first) but registration metadata (SSH/age keys) went stale.

## Changes
- Add a portable **`run_timeout SECS CMD...`** helper next to `info/ok/warn/err`: prefers coreutils `timeout`→`gtimeout` (Linux/nix), falls back to a **fork-based perl alarm** (macOS ships `/usr/bin/perl` but has no `timeout`) where the parent SIGKILLs the child on overrun and exits 124 like GNU `timeout`; the child `exec`s the command so stdout passes through for `$()` capture.
- Wrap the four daemon/network shellouts in `register_device`: `tailscale ip -4` (5s), `nix --version` (5s), `darwin-rebuild`/`nixos-rebuild list-generations` (10s). Existing `|| echo ""` makes callers degrade to empty fields on timeout.
- Out of scope (already bounded): the two `curl` calls use `--max-time 5`; `uptime`/`cat`/`age-keygen` are local and can't hang; the Python collector sections already pass per-call `timeout=`.

## Testing
`bash -n` clean. Functionally exercised the **real** extracted `run_timeout` on macOS (the perl-fallback path — this host has neither `timeout` nor `gtimeout`):
- fast command passes output + rc 0 (`captured-ok`);
- `run_timeout 1 sleep 5` killed at **~1s** (not 5s), rc non-zero → caller degrades;
- simulated hung tailscale → `ts_ip=''` (AC2);
- no lingering sleeper/perl processes after the kill (AC3).

## Acceptance criteria (rh7/rh-device-management#61)
- [x] No `register_device` subprocess can run longer than ~10s without being killed
- [x] If the Tailscale CLI hangs, the audit completes with empty tailscale fields instead of blocking
- [x] A LaunchAgent firing on a host with broken Tailscale doesn't accumulate zombie bash processes

Refs rh7/rh-device-management#61 (cross-repo — closing keywords don't fire across repos, so that issue will be closed manually on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)