### PR TITLE
chore(onboarding): hostname-case fix + recurring-audit install + legacy-job retire + nix.enable doc

### DIFF
--- a/modules/darwin/defaults.nix
+++ b/modules/darwin/defaults.nix
@@ -95,7 +95,10 @@
   # ── System ───────────────────────────────────────────────────────────────
   security.pam.services.sudo_local.touchIdAuth = true;
 
-  # Determinate Nix manages its own daemon — don't let nix-darwin conflict
+  # The official NixOS installer owns the org.nixos.nix-daemon LaunchDaemon (the
+  # fleet migrated off Determinate); nix-darwin must NOT also manage the daemon or
+  # the two conflict. setup.sh installs Nix + patches /etc/nix/nix.conf itself, so
+  # keep nix.enable = false. (#49)
   nix.enable = false;
 
   # Required for nix-darwin (primaryUser is set per-host in mkMac)

--- a/scripts/audit-device.sh
+++ b/scripts/audit-device.sh
@@ -15,7 +15,13 @@
 
 set -euo pipefail
 
-HOSTNAME="$(hostname | tr '[:upper:]' '[:lower:]' | sed 's/\.local$//')"
+# Preserve the hostname's canonical case (#62). The config service uses hostname
+# as the devices-table PRIMARY KEY, and setup.sh registers + the flake names hosts
+# in canonical case (scutil --set HostName "$HOSTNAME"). Lowercasing here made the
+# daily audit POST under a different case, creating a SECOND (duplicate) row for
+# any mixed-case host (e.g. Kassie-M5-Air13 vs kassie-m5-air13). Match setup/flake:
+# strip a trailing .local, keep the case as the OS reports it.
+HOSTNAME="$(hostname | sed 's/\.local$//')"
 OS="$(uname -s)"
 ARCH="$(uname -m)"
 MODE="${1:-interactive}"

--- a/scripts/collector-runner.sh
+++ b/scripts/collector-runner.sh
@@ -126,12 +126,19 @@ PLIST
     launchctl unload "$PLIST" 2>/dev/null || true
     launchctl load "$PLIST"
     log "installed LaunchAgent $LABEL (daily $(printf '%d:%02d' "$hour" "$minute"))"
+    # Supersede the legacy direct-audit job (#38, #83): collector-runner replaces
+    # it, so retire com.rh7.audit to avoid two daily audits firing.
     if [ -f "$HOME/Library/LaunchAgents/com.rh7.audit.plist" ]; then
-      log "NOTE: com.rh7.audit is still installed — remove it (audit-device.sh --uninstall) to avoid double audits"
+      launchctl unload "$HOME/Library/LaunchAgents/com.rh7.audit.plist" 2>/dev/null || true
+      rm -f "$HOME/Library/LaunchAgents/com.rh7.audit.plist"
+      log "retired legacy com.rh7.audit LaunchAgent (superseded by $LABEL)"
     fi
   else
     local min=$(( RANDOM % 30 ))
-    (crontab -l 2>/dev/null | grep -v 'fleet-collector-runner'; echo "${min} 8 * * * bash ${self} # fleet-collector-runner") | crontab -
+    # `|| true`: under `set -euo pipefail`, a fresh user with no crontab makes
+    # `crontab -l | grep` exit non-zero and would abort before the echo, silently
+    # installing no schedule. Keep the existing entries (if any) + append ours.
+    (crontab -l 2>/dev/null | grep -v 'fleet-collector-runner' || true; echo "${min} 8 * * * bash ${self} # fleet-collector-runner") | crontab -
     log "installed cron (daily 8:$(printf '%02d' "$min"))"
   fi
 }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -665,6 +665,21 @@ else
 fi
 
 # ══════════════════════════════════════════════════════════════════════════════
+# Recurring audit schedule — setup.sh runs ONCE; this keeps the device reporting
+# ══════════════════════════════════════════════════════════════════════════════
+header "Recurring audit schedule"
+if [[ -x "$DOTFILES_DIR/scripts/collector-runner.sh" ]]; then
+  # Pull-based collector (issue #83): a daily LaunchAgent/cron fetches + runs the
+  # current collector from the config service and supersedes the old com.rh7.audit
+  # job (#38). Without this, an onboarded device registers once and never re-audits.
+  "$DOTFILES_DIR/scripts/collector-runner.sh" --install \
+    && ok "Daily audit schedule installed (com.rh7.collector-runner)" \
+    || warn "Audit schedule not installed — run scripts/collector-runner.sh --install later"
+else
+  warn "collector-runner.sh not found — skipping recurring audit install"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
 # Done
 # ══════════════════════════════════════════════════════════════════════════════
 echo ""


### PR DESCRIPTION
Phase A prep for cleanly switching the next MacBook (rouven-air-m2) to Nix — the repeatable onboarding gaps surfaced by a readiness audit. Four cohesive changes; **#93 firewall is deliberately NOT here** (it needs role-targeting + a macOS-26 mechanism decision — separate).

## Changes
- **`audit-device.sh` — stop lowercasing the hostname (#62).** The config service keys the `devices` table on hostname (PK); `setup.sh` + the flake register hosts in **canonical case** (`scutil --set HostName`). Lowercasing made the daily audit POST under a different case → a **duplicate row** for any mixed-case host (live: `Kassie-M5-Air13` vs `kassie-m5-air13`). Now strips only a trailing `.local`, preserving case.
- **`setup.sh` — install the recurring audit schedule** at the end of onboarding via `collector-runner.sh --install`. Without this a freshly-onboarded device registered **once and never re-audited** (the schedule install was never wired into setup). Degrades gracefully if the script is absent.
- **`collector-runner.sh` — actually retire the legacy `com.rh7.audit`** on `--install` (it previously only *logged* a note), so it truly supersedes the old direct-audit job per CLAUDE.md (#38, #83) instead of running two daily audits. Also guard the Linux cron install with `|| true` so an empty crontab under `set -euo pipefail` can't silently abort before appending the job.
- **`defaults.nix` — fix the stale `nix.enable = false` comment (#49).** The fleet is on the **official** installer (not Determinate); that daemon owns `org.nixos.nix-daemon`, so nix-darwin must not also manage it. Decision: keep `false`.

## Testing
- `bash -n` clean on all three scripts; `nix-instantiate --parse` on `defaults.nix`.
- `#62`: confirmed `Kassie-M5-Air13.local → Kassie-M5-Air13` (case preserved, `.local` stripped) and `rouven-air-m2` unchanged.
- Crontab guard: `|| true` matches the existing pattern in the uninstall branch; prevents the pipefail-abort failure class on a fresh empty crontab.

## Codex review
Ran `codex exec review --uncommitted`. It surfaced the legacy-job-not-removed and empty-crontab issues in `collector-runner.sh` — **both fixed here**. One finding deferred: collector-runner doesn't persist a custom `--config-server` into the scheduled job — the standard fleet discovers the Studio via the baked-in probe list, so it's unaffected; noted as a follow-up.

Refs rh7/rh-device-management#62, rh7/rh-device-management#49, rh7/rh-device-management#38, rh7/rh-device-management#83 (cross-repo — closing keywords don't fire across repos; I'll close #62 and #49 manually on merge, and advance #38/#83).

🤖 Generated with [Claude Code](https://claude.com/claude-code)