### PR TITLE
ci: flake-check — eval all darwinConfigurations on every push/PR (#12)

### DIFF
--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -1,0 +1,60 @@
+name: flake check
+
+# Catch a broken flake (eval errors, bad options, missing files, a malformed new
+# host entry) BEFORE it reaches a device — onboarding builds the flake live on the
+# new Mac and setup.sh masks darwin-rebuild failures, so without this a broken
+# config only surfaces during an onboard. See rh7/rh-device-management#12.
+#
+# Gate = pure EVALUATION of every darwinConfiguration's system derivation
+# (--no build). Evaluation is cross-platform, so a cheap Linux runner can validate
+# the aarch64-darwin Mac configs without macOS minutes and without building.
+# (`nix flake check --all-systems` is intentionally NOT used: it cross-evaluates
+# the aarch64-linux nixos-vm config against an x86_64-only package and false-fails.)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: flake-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  eval-darwin-configs:
+    name: eval darwinConfigurations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix (official installer)
+        uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Evaluate every darwinConfiguration (no build)
+        run: |
+          set -euo pipefail
+          hosts=$(nix eval --json '.#darwinConfigurations' --apply 'builtins.attrNames' | jq -r '.[]')
+          echo "darwinConfigurations: $(echo "$hosts" | tr '\n' ' ')"
+          fail=0
+          for h in $hosts; do
+            echo "::group::eval $h"
+            if nix eval ".#darwinConfigurations.\"$h\".system.drvPath" >/dev/null; then
+              echo "$h: OK"
+            else
+              echo "$h: EVAL FAILED"
+              fail=1
+            fi
+            echo "::endgroup::"
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::one or more darwinConfigurations failed to evaluate"
+            exit 1
+          fi
+          echo "all darwinConfigurations evaluate cleanly"


### PR DESCRIPTION
## Problem
The dotfiles flake drives the whole fleet but had **no CI**. A broken config (eval error, bad option, missing file, a malformed new host entry) only surfaced at **onboarding time** on a real Mac — and `setup.sh` masks `darwin-rebuild` failures as "non-fatal brew bundle", so a broken flake could silently leave a device un-built.

## Change
`.github/workflows/flake-check.yml`: on push/PR to `main`, install Nix (official installer via `cachix/install-nix-action`) and **evaluate every `darwinConfiguration`'s `system` derivation** (`nix eval … .system.drvPath`, **no build**). Evaluation is cross-platform, so a cheap **Linux** runner validates the aarch64-darwin Mac configs — no macOS minutes, no builds.

Deliberately **not** `nix flake check --all-systems`: it cross-evaluates the `aarch64-linux` `nixos-vm` config against an x86_64-only package (`notion-app-enhanced`) and false-fails. The targeted darwin eval is what matters for Mac onboarding and is reliably green.

## Testing
Validated locally — all 8 darwinConfigurations eval clean:
```
Kassie-M5-Air13, m5-air, rouven-air-m2, rouven-air-m3,
rouven-m5-pro, rouven-pro-m4, rouvens-mac-mini, rouvens-mac-studio  → all OK
```
YAML validated (ruby). This PR triggers the workflow on itself, so the check below is the first live run.

## Follow-ups (out of scope)
- NixOS configs (`thinkpad`, `nixos-vm`) not yet evaluated in CI — `nixos-vm` (aarch64-linux) trips an x86_64-only package; needs `allowUnsupportedSystem` handling or a matched runner.
- `cachix/install-nix-action` pin may need a version bump over time.

Refs rh7/rh-device-management#12

🤖 Generated with [Claude Code](https://claude.com/claude-code)