### PR TITLE
feat(collector-runner): self-bootstrap when run clone-free (rh-device-management#119)

### DIFF
--- a/scripts/collector-runner.sh
+++ b/scripts/collector-runner.sh
@@ -26,10 +26,16 @@ set -euo pipefail
 COLLECTOR="${COLLECTOR:-audit-device.sh}"
 RUN_ARGS="${COLLECTOR_RUN_ARGS:---run}"
 CACHE_DIR="${COLLECTOR_CACHE_DIR:-$HOME/.cache/fleet-collector}"
-LABEL="com.rh7.collector-runner"
+LABEL="${COLLECTOR_LABEL:-com.rh7.collector-runner}"
 PLIST="$HOME/Library/LaunchAgents/${LABEL}.plist"
+# Short link to THIS runner (Vercel rewrite -> raw dotfiles). Used to self-install
+# a persistent copy when the runner is invoked clone-free via `curl … | bash`, so
+# a no-clone device can still get the gated pull path instead of the un-gated
+# audit fallback (rh-device-management#119).
+RUNNER_URL="${COLLECTOR_RUNNER_URL:-https://config.rh7labs.com/collector-runner}"
 OS="$(uname -s)"
 CACHE="$CACHE_DIR/$COLLECTOR"
+RUNNER_SELF="$CACHE_DIR/collector-runner.sh"
 LOG="$CACHE_DIR/runner.log"
 
 mkdir -p "$CACHE_DIR"
@@ -100,8 +106,26 @@ fetch_and_verify() {  # writes $CACHE on success
   log "fetched $COLLECTOR ok ($want) from $base"
 }
 
+# Absolute path to a persistent copy of THIS runner for the scheduled job to
+# exec daily. With a real on-disk clone, schedule it in place. When run clone-free
+# via `curl … | bash` ($0 is "bash"/stdin, not a readable script), self-install a
+# copy into the cache dir and schedule THAT — this is what lets a no-clone device
+# get the sha256/scan-gated pull path instead of the un-gated audit fallback
+# (rh-device-management#119). The runner script itself updates only on a re-install
+# or clone pull; the AUDIT logic it pulls still changes centrally (#83).
+resolve_self() {
+  if [ -f "$0" ] && [ -r "$0" ]; then
+    printf '%s\n' "$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+    return 0
+  fi
+  log "no on-disk runner (\$0='$0') — self-installing from $RUNNER_URL to $RUNNER_SELF"
+  curl -fsSL --max-time 30 "$RUNNER_URL" -o "$RUNNER_SELF" || { log "failed to fetch runner from $RUNNER_URL"; return 1; }
+  chmod +x "$RUNNER_SELF"
+  printf '%s\n' "$RUNNER_SELF"
+}
+
 install_schedule() {
-  local self; self="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+  local self; self="$(resolve_self)" || { log "cannot resolve runner path for schedule — aborting install"; return 1; }
   if [ "$OS" = "Darwin" ]; then
     local hour=8 minute=$(( RANDOM % 30 ))
     mkdir -p "$HOME/Library/LaunchAgents"

--- a/scripts/collector-runner.sh
+++ b/scripts/collector-runner.sh
@@ -114,7 +114,11 @@ fetch_and_verify() {  # writes $CACHE on success
 # (rh-device-management#119). The runner script itself updates only on a re-install
 # or clone pull; the AUDIT logic it pulls still changes centrally (#83).
 resolve_self() {
-  if [ -f "$0" ] && [ -r "$0" ]; then
+  # Accept $0 only if it is actually an on-disk collector-runner.sh. A piped
+  # invocation sets $0 to the shell — "bash", or "/bin/bash" which IS a readable
+  # file — so a bare `[ -f "$0" ]` would hand back the shell binary and the
+  # schedule would exec `bash /bin/bash` (collector never runs). Match the name.
+  if [ -f "$0" ] && [ -r "$0" ] && [ "$(basename "$0")" = "collector-runner.sh" ]; then
     printf '%s\n' "$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
     return 0
   fi


### PR DESCRIPTION
## What
`collector-runner.sh` now self-installs a persistent copy of itself when invoked clone-free (piped via `curl … | bash`), so the sha256/scan/ref-gated pull path works without a local dotfiles clone.

## Why
`install_schedule` baked the runner's own on-disk `$self` path into the LaunchAgent/cron entry, so a piped `curl … | bash -s -- --install` produced a broken (or no) schedule — forcing no-clone devices onto the **un-gated** `com.rh7.audit` fallback. That's the concrete reason the auto-updating gated path wasn't the universal default (see rh7/rh-device-management#119).

## Change
- `resolve_self()`: if `$0` is a readable on-disk script (real clone), schedule it in place (unchanged). If piped (`$0` is `bash`/stdin), fetch the runner from the new `config.rh7labs.com/collector-runner` short link into `$CACHE_DIR/collector-runner.sh` and schedule **that**.
- `LABEL` is now env-overridable (`COLLECTOR_LABEL`) for testability.

Trust model matches the existing `curl … /audit` bootstrap (TLS over the public short link for the initial fetch); thereafter every **audit** the runner runs stays sha256 + read-only-scan + pinned-ref gated over Tailscale. The runner script updates only on re-install/clone-pull; the **audit logic it pulls still changes centrally** (rh7/rh-device-management#83).

## Verification
- `bash -n` clean.
- Piped install (throwaway label + local HTTP server): self-installs to the cache dir; the LaunchAgent `ProgramArguments` points at the cached copy, not `bash`.
- On-disk install: resolves to the real `~/dotfiles/scripts/collector-runner.sh` path.
- Real `com.rh7.collector-runner` untouched; test artifacts cleaned up.

## Pairing
Requires the `/collector-runner` Vercel rewrite — rh7/rh-device-management#121. After both land + the site redeploys, clone-free enrollment is `curl -fsSL config.rh7labs.com/collector-runner | bash -s -- --install` → gated daily audits.

Refs rh7/rh-device-management#119 (closed by #121).

🤖 Generated with [Claude Code](https://claude.com/claude-code)