### PR TITLE
feat(collector-runner): short-link primary + raw-dotfiles fallback for self-install (#119)

### DIFF
--- a/scripts/collector-runner.sh
+++ b/scripts/collector-runner.sh
@@ -28,11 +28,15 @@ RUN_ARGS="${COLLECTOR_RUN_ARGS:---run}"
 CACHE_DIR="${COLLECTOR_CACHE_DIR:-$HOME/.cache/fleet-collector}"
 LABEL="${COLLECTOR_LABEL:-com.rh7.collector-runner}"
 PLIST="$HOME/Library/LaunchAgents/${LABEL}.plist"
-# Short link to THIS runner (Vercel rewrite -> raw dotfiles). Used to self-install
-# a persistent copy when the runner is invoked clone-free via `curl … | bash`, so
-# a no-clone device can still get the gated pull path instead of the un-gated
-# audit fallback (rh-device-management#119).
+# Source(s) to self-install THIS runner from when invoked clone-free via
+# `curl … | bash`, so a no-clone device gets the gated pull path instead of the
+# un-gated audit fallback (rh-device-management#119). PRIMARY is the
+# config.rh7labs.com short link (a Vercel rewrite -> raw dotfiles); FALLBACK is
+# the raw dotfiles URL the short link proxies, tried if the short link is
+# undeployed/lagging (the #39 alias trap). Both are TLS; the AUDIT the runner
+# later pulls is still sha256 + scan + ref gated regardless of bootstrap source.
 RUNNER_URL="${COLLECTOR_RUNNER_URL:-https://config.rh7labs.com/collector-runner}"
+RUNNER_URL_FALLBACK="${COLLECTOR_RUNNER_URL_FALLBACK:-https://raw.githubusercontent.com/rh7/dotfiles/main/scripts/collector-runner.sh}"
 OS="$(uname -s)"
 CACHE="$CACHE_DIR/$COLLECTOR"
 RUNNER_SELF="$CACHE_DIR/collector-runner.sh"
@@ -122,10 +126,22 @@ resolve_self() {
     printf '%s\n' "$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
     return 0
   fi
-  log "no on-disk runner (\$0='$0') — self-installing from $RUNNER_URL to $RUNNER_SELF"
-  curl -fsSL --max-time 30 "$RUNNER_URL" -o "$RUNNER_SELF" || { log "failed to fetch runner from $RUNNER_URL"; return 1; }
-  chmod +x "$RUNNER_SELF"
-  printf '%s\n' "$RUNNER_SELF"
+  # Clone-free: self-install a persistent copy. Try the short link (primary),
+  # then the raw dotfiles URL (fallback) so enrollment still works if the Vercel
+  # route is undeployed/lagging (#39).
+  log "no on-disk runner (\$0='$0') — self-installing to $RUNNER_SELF"
+  local url
+  for url in "$RUNNER_URL" "$RUNNER_URL_FALLBACK"; do
+    if curl -fsSL --max-time 30 "$url" -o "$RUNNER_SELF" 2>/dev/null; then
+      chmod +x "$RUNNER_SELF"
+      log "self-installed runner from $url"
+      printf '%s\n' "$RUNNER_SELF"
+      return 0
+    fi
+    log "runner fetch failed from $url"
+  done
+  log "failed to fetch runner from primary ($RUNNER_URL) and fallback ($RUNNER_URL_FALLBACK)"
+  return 1
 }
 
 install_schedule() {

--- a/scripts/collector-runner.sh
+++ b/scripts/collector-runner.sh
@@ -31,12 +31,16 @@ PLIST="$HOME/Library/LaunchAgents/${LABEL}.plist"
 # Source(s) to self-install THIS runner from when invoked clone-free via
 # `curl … | bash`, so a no-clone device gets the gated pull path instead of the
 # un-gated audit fallback (rh-device-management#119). PRIMARY is the
-# config.rh7labs.com short link (a Vercel rewrite -> raw dotfiles); FALLBACK is
-# the raw dotfiles URL the short link proxies, tried if the short link is
-# undeployed/lagging (the #39 alias trap). Both are TLS; the AUDIT the runner
-# later pulls is still sha256 + scan + ref gated regardless of bootstrap source.
-RUNNER_URL="${COLLECTOR_RUNNER_URL:-https://config.rh7labs.com/collector-runner}"
-RUNNER_URL_FALLBACK="${COLLECTOR_RUNNER_URL_FALLBACK:-https://raw.githubusercontent.com/rh7/dotfiles/main/scripts/collector-runner.sh}"
+# config.rh7labs.com short link (a Vercel rewrite -> raw dotfiles). The built-in
+# raw-dotfiles fallback is auto-used ONLY when the primary is this default short
+# link (so enrollment survives the short link being undeployed/lagging — the #39
+# alias trap). A CUSTOM COLLECTOR_RUNNER_URL (staging/fork) fails closed unless
+# the operator also sets COLLECTOR_RUNNER_URL_FALLBACK, so a custom primary's
+# transient failure never silently installs main's runner. Both are TLS; the
+# AUDIT the runner later pulls is still sha256 + scan + ref gated regardless.
+RUNNER_URL_DEFAULT="https://config.rh7labs.com/collector-runner"
+RUNNER_RAW_FALLBACK="https://raw.githubusercontent.com/rh7/dotfiles/main/scripts/collector-runner.sh"
+RUNNER_URL="${COLLECTOR_RUNNER_URL:-$RUNNER_URL_DEFAULT}"
 OS="$(uname -s)"
 CACHE="$CACHE_DIR/$COLLECTOR"
 RUNNER_SELF="$CACHE_DIR/collector-runner.sh"
@@ -126,12 +130,19 @@ resolve_self() {
     printf '%s\n' "$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
     return 0
   fi
-  # Clone-free: self-install a persistent copy. Try the short link (primary),
-  # then the raw dotfiles URL (fallback) so enrollment still works if the Vercel
-  # route is undeployed/lagging (#39).
+  # Clone-free: self-install a persistent copy. Try the primary, then a fallback.
+  # The built-in raw-dotfiles fallback is auto-used ONLY when the primary is the
+  # default short link; a custom COLLECTOR_RUNNER_URL fails closed unless the
+  # operator sets COLLECTOR_RUNNER_URL_FALLBACK explicitly.
   log "no on-disk runner (\$0='$0') — self-installing to $RUNNER_SELF"
+  local fallback=""
+  if [ -n "${COLLECTOR_RUNNER_URL_FALLBACK:-}" ]; then
+    fallback="$COLLECTOR_RUNNER_URL_FALLBACK"
+  elif [ "$RUNNER_URL" = "$RUNNER_URL_DEFAULT" ]; then
+    fallback="$RUNNER_RAW_FALLBACK"
+  fi
   local url
-  for url in "$RUNNER_URL" "$RUNNER_URL_FALLBACK"; do
+  for url in "$RUNNER_URL" ${fallback:+"$fallback"}; do
     if curl -fsSL --max-time 30 "$url" -o "$RUNNER_SELF" 2>/dev/null; then
       chmod +x "$RUNNER_SELF"
       log "self-installed runner from $url"
@@ -140,7 +151,7 @@ resolve_self() {
     fi
     log "runner fetch failed from $url"
   done
-  log "failed to fetch runner from primary ($RUNNER_URL) and fallback ($RUNNER_URL_FALLBACK)"
+  log "failed to fetch runner (primary $RUNNER_URL${fallback:+, fallback $fallback})"
   return 1
 }
 


### PR DESCRIPTION
## What
Make the clone-free runner self-install resilient: try the `config.rh7labs.com/collector-runner` short link (**primary**, nice UX), then fall back to the raw dotfiles URL it proxies (**fallback**, always available).

## Why
The short-link route needs a Vercel (re)deploy + the domain bound to Production (#39). Until then, no-clone enrollment 404s and the self-install fails. The raw dotfiles URL is the same source the short link proxies and works immediately — so enrollment never breaks, and the short link "just works" once deployed.

## Safety (codex review applied)
- Built-in raw-dotfiles fallback is auto-used **only when the primary is the default short link**. A **custom** `COLLECTOR_RUNNER_URL` (staging/fork) **fails closed** unless `COLLECTOR_RUNNER_URL_FALLBACK` is set — so a custom primary's transient failure never silently installs main's runner.
- Both URLs are TLS bootstrap; the **audit** the runner later pulls is still sha256 + read-only-scan + pinned-ref gated regardless of source.
- If everything fails, install aborts before writing a schedule (no broken LaunchAgent/cron).

## Verification
- syntax (`bash -n`).
- custom-primary-dead + no fallback → **fails closed**, no plist written.
- custom + explicit fallback → uses it.
- default short link (404, undeployed) → **auto-falls back to raw GitHub and self-installs** (live test); agent points at the cached copy.
- real `com.rh7.collector-runner` untouched throughout.

Part of #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)