### PR TITLE
chore: m5-pro rebuild hardening (nrsg guarded alias)

### DIFF
--- a/modules/shell/zsh.nix
+++ b/modules/shell/zsh.nix
@@ -39,6 +39,11 @@ in {
         else "sudo nixos-rebuild switch --flake ~/dotfiles";
       nup = "nix flake update ~/dotfiles";
 
+      # Guarded rebuild (build → drift audit → nvd diff → confirm → switch).
+      # Use instead of `nrs` when you want to review/approve changes first —
+      # `nrs` is raw darwin-rebuild and skips the drift guard entirely.
+      nrsg = "~/dotfiles/scripts/rebuild.sh";
+
       # Quick access
       dots = "cd ~/dotfiles && zed .";
     };


### PR DESCRIPTION
Adds `nrsg` → `scripts/rebuild.sh` (build → drift audit → nvd diff → confirm → switch), leaving `nrs` raw/fast. Addresses the root cause of the silent MAS-app uninstall: `nrs` bypasses the drift guard.

Will append `pwa_check` warnings for Penumbra & Kubera to this branch once URLs are confirmed, then merge as one.