### PR TITLE
fix: validated device-identity resolver — stop phantom "hostname" registrations (#33)

### DIFF
--- a/scripts/audit-device.sh
+++ b/scripts/audit-device.sh
@@ -15,13 +15,44 @@
 
 set -euo pipefail
 
-# Preserve the hostname's canonical case (#62). The config service uses hostname
-# as the devices-table PRIMARY KEY, and setup.sh registers + the flake names hosts
-# in canonical case (scutil --set HostName "$HOSTNAME"). Lowercasing here made the
+# Resolve a trustworthy device identity (#33 / rh-device-management#150).
+# `$(hostname)` alone is fragile: on a minimal Linux box the binary may be
+# absent (→ empty), or the box may carry a placeholder name ("hostname",
+# "localhost"), or a paste/CRLF artifact may sneak in — any of which used to
+# register a PHANTOM device + workloads under a bogus identity (a daily audit on
+# the Coolify box did exactly this). Try several sources (uname -n and
+# /etc/hostname work even without the `hostname` binary), validate, and FAIL LOUD
+# rather than send junk. Mirrors the server's isValidDeviceIdentity() guard.
+#
+# Preserve the hostname's canonical CASE (#62): the config service uses hostname
+# as the devices-table PRIMARY KEY, and setup.sh + the flake name hosts in
+# canonical case (scutil --set HostName "$HOSTNAME"). Lowercasing here made the
 # daily audit POST under a different case, creating a SECOND (duplicate) row for
-# any mixed-case host (e.g. Kassie-M5-Air13 vs kassie-m5-air13). Match setup/flake:
-# strip a trailing .local, keep the case as the OS reports it.
-HOSTNAME="$(hostname | sed 's/\.local$//')"
+# any mixed-case host (e.g. Kassie-M5-Air13 vs kassie-m5-air13). So we strip a
+# trailing .local and keep the case as the OS reports it — NO lowercasing.
+resolve_hostname() {
+  local cand raw=""
+  for cand in "$(hostname 2>/dev/null || true)" "$(uname -n 2>/dev/null || true)" \
+              "$(cat /etc/hostname 2>/dev/null || true)" "${HOSTNAME:-}"; do
+    cand="$(printf '%s' "$cand" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    cand="${cand%.local}"
+    if [[ -n "$cand" ]]; then raw="$cand"; break; fi
+  done
+  local lc; lc="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+  case "$lc" in
+    ""|hostname|localhost|localhost.localdomain) return 1 ;;
+  esac
+  if [[ "$raw" =~ [[:space:]] || "$raw" == *'$('* || "$raw" == *'`'* || "$raw" == *'/'* ]]; then
+    return 1
+  fi
+  printf '%s' "$raw"   # original case preserved (#62)
+}
+
+HOSTNAME="$(resolve_hostname)" || {
+  echo "[ERROR] Could not determine a valid hostname (got empty or a placeholder like 'hostname'/'localhost')." >&2
+  echo "        Set a real hostname and retry — Linux: sudo hostnamectl set-hostname <name>; macOS: sudo scutil --set HostName <name>" >&2
+  exit 1
+}
 OS="$(uname -s)"
 ARCH="$(uname -m)"
 MODE="${1:-interactive}"

--- a/scripts/device
+++ b/scripts/device
@@ -12,7 +12,38 @@
 set -euo pipefail
 
 DOTFILES_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-HOSTNAME="$(hostname | tr '[:upper:]' '[:lower:]' | sed 's/\.local$//')"
+# Resolve a trustworthy device identity (#33 / rh-device-management#150).
+# `$(hostname)` alone is fragile: on a minimal Linux box the binary may be
+# absent (→ empty), or the box may carry a placeholder name ("hostname",
+# "localhost"), or a paste/CRLF artifact may sneak in — any of which used to
+# register a PHANTOM device + workloads under a bogus identity. Try several
+# sources (uname -n and /etc/hostname work even without the `hostname` binary),
+# validate the result, and FAIL LOUD rather than send junk. Mirrors the server's
+# isValidDeviceIdentity() guard so both ends agree on what a valid name is.
+resolve_hostname() {
+  local cand raw=""
+  for cand in "$(hostname 2>/dev/null || true)" "$(uname -n 2>/dev/null || true)" \
+              "$(cat /etc/hostname 2>/dev/null || true)" "${HOSTNAME:-}"; do
+    cand="$(printf '%s' "$cand" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    cand="${cand%.local}"
+    if [[ -n "$cand" ]]; then raw="$cand"; break; fi
+  done
+  local lc; lc="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+  case "$lc" in
+    ""|hostname|localhost|localhost.localdomain) return 1 ;;
+  esac
+  if [[ "$raw" =~ [[:space:]] || "$raw" == *'$('* || "$raw" == *'`'* || "$raw" == *'/'* ]]; then
+    return 1
+  fi
+  printf '%s' "$raw"
+}
+
+HOSTNAME="$(resolve_hostname)" || {
+  echo "[ERROR] Could not determine a valid hostname (got empty or a placeholder like 'hostname'/'localhost')." >&2
+  echo "        Set a real hostname and retry — Linux: sudo hostnamectl set-hostname <name>; macOS: sudo scutil --set HostName <name>" >&2
+  exit 1
+}
+HOSTNAME="$(printf '%s' "$HOSTNAME" | tr '[:upper:]' '[:lower:]')"
 OS="$(uname -s)"
 ARCH="$(uname -m)"
 

--- a/scripts/heartbeat.sh
+++ b/scripts/heartbeat.sh
@@ -11,7 +11,39 @@
 
 set -euo pipefail
 
-HOSTNAME="$(hostname | tr '[:upper:]' '[:lower:]' | sed 's/\.local$//')"
+# Resolve a trustworthy device identity (#33 / rh-device-management#150).
+# `$(hostname)` alone is fragile: on a minimal Linux box the binary may be
+# absent (→ empty), or the box may carry a placeholder name ("hostname",
+# "localhost"), or a paste/CRLF artifact may sneak in — any of which used to
+# register a PHANTOM device + workloads under a bogus identity. Try several
+# sources (uname -n and /etc/hostname work even without the `hostname` binary),
+# validate, and skip the heartbeat rather than send junk. Mirrors the server's
+# isValidDeviceIdentity() guard so both ends agree on what a valid name is.
+resolve_hostname() {
+  local cand raw=""
+  for cand in "$(hostname 2>/dev/null || true)" "$(uname -n 2>/dev/null || true)" \
+              "$(cat /etc/hostname 2>/dev/null || true)" "${HOSTNAME:-}"; do
+    cand="$(printf '%s' "$cand" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    cand="${cand%.local}"
+    if [[ -n "$cand" ]]; then raw="$cand"; break; fi
+  done
+  local lc; lc="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+  case "$lc" in
+    ""|hostname|localhost|localhost.localdomain) return 1 ;;
+  esac
+  if [[ "$raw" =~ [[:space:]] || "$raw" == *'$('* || "$raw" == *'`'* || "$raw" == *'/'* ]]; then
+    return 1
+  fi
+  printf '%s' "$raw"
+}
+
+# Cron job (every 5 min): skip quietly on an invalid identity instead of failing
+# loud — the server would 400 it anyway, and exit 1 here would spam cron mail.
+HOSTNAME="$(resolve_hostname)" || {
+  echo "[heartbeat] no valid hostname (empty/placeholder); skipping heartbeat" >&2
+  exit 0
+}
+HOSTNAME="$(printf '%s' "$HOSTNAME" | tr '[:upper:]' '[:lower:]')"
 OS="$(uname -s)"
 ARCH="$(uname -m)"
 


### PR DESCRIPTION
**Draft** — the in-repo fix is complete and unit-tested, but the *root cause on the live Coolify box* (`100.113.133.55`) should be confirmed before merge (see Verification → live).

Closes #33. Refs rh7/rh-device-management#150 (Slice C).

## Problem
A live Coolify box self-registered under the literal string `hostname` + 39 phantom workloads (rh7/rh-device-management#150). All three device-side scripts derive identity via a bare `HOSTNAME="$(hostname | ...)"`, which is fragile:
- on a minimal Linux box the `hostname` **binary may be absent** → empty;
- the box may carry a **placeholder** name (`hostname` / `localhost`);
- a **paste/CRLF artifact** can sneak in.

Any of those got sent verbatim as the device primary key.

## Fix
A `resolve_hostname()` helper added to `scripts/device`, `scripts/heartbeat.sh`, `scripts/audit-device.sh`:
- **Multi-source**, first non-empty wins: `hostname` → `uname -n` → `/etc/hostname` → `$HOSTNAME`. `uname -n` / `/etc/hostname` recover the real name even when the `hostname` binary is missing — the most likely Coolify cause.
- Trims surrounding whitespace/CR, strips a trailing `.local`.
- **Validates** against the same denylist the server uses (`isValidDeviceIdentity()`, #150 Slice A): rejects empty, `hostname`, `localhost`, `localhost.localdomain`, shell-meta / whitespace / `/`.
- **Fails loud** (device + audit: `exit 1` with a fix hint) or **skips quietly** (heartbeat cron: `exit 0`, no 5-min mail spam) instead of sending junk.
- `audit-device.sh` keeps canonical **case** (#62 — no lowercasing); `device`/`heartbeat` lowercase after resolution (unchanged behaviour).

## Verification
**Static:** `bash -n` clean on all three. Resolver unit-tested in isolation across 8 scenarios:

| input | result |
|---|---|
| literal `hostname` (the bug) | **REJECT** |
| `localhost` | **REJECT** |
| binary missing, `/etc/hostname`=`coolify-prod` | accept `coolify-prod` |
| binary missing, `uname -n`=`coolify-vps` | accept `coolify-vps` |
| `myhost\r\n` (CRLF paste) | accept `myhost` |
| `Rouvens-Mac-Studio.local` | accept `Rouvens-Mac-Studio` (case kept) |
| `vmi…contaboserver.net` (FQDN VPS) | accept (must still pass) |
| all sources empty | **REJECT** (fail loud) |

**Live (before merge):** on the Coolify box, run `scripts/audit-device.sh --local` and confirm it now resolves the real hostname (or fails loud telling you to set one), then re-register and check `GET /api/devices/<realname>` exists and the literal `hostname` row stays gone. This is why the PR is a draft — confirm the box's actual `hostname`/`uname -n`/`/etc/hostname` state matches the assumed root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)