### PR TITLE
fix(enroll): reliably install the daily schedule; stop false 'enrolled'

### DIFF
--- a/scripts/audit-device.sh
+++ b/scripts/audit-device.sh
@@ -186,13 +186,33 @@ PLIST
 }
 
 install_crontab() {
-  local audit_cmd cron_min cron_line
+  local audit_cmd cron_min cron_line existing new_crontab
+  if ! command -v crontab >/dev/null 2>&1; then
+    err "cron is not installed on this host — the daily audit was NOT scheduled."
+    err "Install it and re-run, e.g.: sudo apt-get install -y cron && sudo systemctl enable --now cron"
+    return 1
+  fi
   audit_cmd="$(build_audit_cmd)"
   cron_min=$(( RANDOM % 30 ))
   cron_line="${cron_min} 8 * * * ${audit_cmd} ${CRON_TAG}"
-  (crontab -l 2>/dev/null | grep -v "$CRON_TAG" | grep -v "$OLD_CRON_TAG"; echo "$cron_line") | crontab -
-  ok "Installed daily audit cron (8:$(printf '%02d' "$cron_min") AM)"
-  info "→ $audit_cmd"
+  # Read the existing crontab, stripping any prior fleet entries. On a fresh box
+  # `crontab -l` is empty, so the `grep -v` filters find no match and exit 1;
+  # under `set -euo pipefail` that used to abort the whole script HERE — before
+  # the new line was ever written — so the schedule silently never installed.
+  # `|| true` neutralizes the empty-input exit; the assignment always succeeds.
+  existing="$(crontab -l 2>/dev/null | grep -v "$CRON_TAG" | grep -v "$OLD_CRON_TAG" || true)"
+  if [[ -n "$existing" ]]; then
+    new_crontab="${existing}"$'\n'"${cron_line}"
+  else
+    new_crontab="${cron_line}"
+  fi
+  if printf '%s\n' "$new_crontab" | crontab -; then
+    ok "Installed daily audit cron (8:$(printf '%02d' "$cron_min") AM)"
+    info "→ $audit_cmd"
+  else
+    err "Failed to write crontab (is the cron service running?) — daily audit NOT scheduled."
+    return 1
+  fi
 }
 
 install_cron() {
@@ -2199,12 +2219,16 @@ register_device() {
 show_checklist() {
   local config_url="$1"
   local role
-  role=$(fetch_device_role "$config_url")
+  # `|| true`: this is a cosmetic display step and MUST NOT abort the script.
+  # Under `set -euo pipefail`, a role the server has no checklist for (e.g.
+  # `server`, which 400s) makes `curl -sf` exit 22 — which used to kill the
+  # whole audit run right here, skipping the cron install that follows.
+  role=$(fetch_device_role "$config_url" || true)
   [[ -z "$role" ]] && role="workstation"
 
   local checklist
-  checklist=$(curl -sf "${config_url}/api/fleet/checklist/${role}" --max-time 5 2>/dev/null)
-  [[ -z "$checklist" ]] && return
+  checklist=$(curl -sf "${config_url}/api/fleet/checklist/${role}" --max-time 5 2>/dev/null || true)
+  [[ -z "$checklist" ]] && return 0
 
   echo "" >&2
   echo -e "${BOLD}${CYAN}┌──────────────────────────────────────────┐${NC}" >&2
@@ -2255,17 +2279,19 @@ case "$MODE" in
       register_device "$CONFIG_URL" \
         && ok "Device registered with fleet" >&2 \
         || warn "Device registration failed" >&2
-      # Show checklist in interactive mode (not cron)
-      if [[ -t 1 || "$MODE" == "--run-and-install" ]] && [[ -z "${CRON_TAG_PRESENT:-}" ]]; then
-        show_checklist "$CONFIG_URL"
-      fi
     else
       warn "Config service not reachable — printing audit locally" >&2
       echo "$AUDIT"
     fi
-    # Install cron if requested
+    # Install the daily schedule FIRST — it's the critical step and must not be
+    # skipped by a later (cosmetic) failure. Runs whether or not the service was
+    # reachable; `|| warn` keeps a failed install from aborting under set -e.
     if [[ "$MODE" == "--run-and-install" ]]; then
-      install_cron
+      install_cron || warn "Daily audit schedule was NOT installed (see message above)" >&2
+    fi
+    # Then the post-setup checklist (cosmetic; only when the service is reachable).
+    if [[ -n "$CONFIG_URL" ]] && { [[ -t 1 || "$MODE" == "--run-and-install" ]]; } && [[ -z "${CRON_TAG_PRESENT:-}" ]]; then
+      show_checklist "$CONFIG_URL"
     fi
     ;;
 esac

--- a/scripts/audit-device.sh
+++ b/scripts/audit-device.sh
@@ -142,7 +142,8 @@ install_launchagent() {
   local hour=8
   local minute=$(( RANDOM % 30 ))
 
-  mkdir -p "$HOME/Library/LaunchAgents"
+  mkdir -p "$HOME/Library/LaunchAgents" || {
+    err "Cannot create ~/Library/LaunchAgents — daily audit NOT scheduled."; return 1; }
   cat > "$LAUNCHAGENT_PLIST" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -178,8 +179,19 @@ install_launchagent() {
 </plist>
 PLIST
 
+  # Explicit checks (don't rely on errexit): install_cron is called as
+  # `install_cron || warn`, which suspends `set -e` inside this function, so a
+  # failed plist write or `launchctl load` would otherwise fall through to the
+  # "Installed" message and falsely return success.
+  if [[ ! -s "$LAUNCHAGENT_PLIST" ]]; then
+    err "Failed to write LaunchAgent plist ($LAUNCHAGENT_PLIST) — daily audit NOT scheduled."
+    return 1
+  fi
   launchctl unload "$LAUNCHAGENT_PLIST" 2>/dev/null || true
-  launchctl load "$LAUNCHAGENT_PLIST"
+  if ! launchctl load "$LAUNCHAGENT_PLIST"; then
+    err "Failed to load LaunchAgent (launchctl load) — daily audit NOT scheduled."
+    return 1
+  fi
   ok "Installed daily audit LaunchAgent ($(printf '%d:%02d' "$hour" "$minute") AM)"
   info "→ $LAUNCHAGENT_PLIST"
   info "→ $audit_cmd"

--- a/scripts/enroll.sh
+++ b/scripts/enroll.sh
@@ -127,13 +127,18 @@ fi
 ok "Config service reachable: ${CONFIG_URL}"
 
 # ── 3. Is the daily audit already scheduled? ───────────────────────────────
+# A function so we can re-check AFTER the audit run (post-flight #6) and catch a
+# silently-failed schedule install instead of reporting a false "enrolled".
+schedule_installed() {
+  if [[ "$OS" == "Darwin" ]]; then
+    # collector-runner supersedes the direct audit agent; either counts as scheduled
+    launchctl list 2>/dev/null | grep -qE 'com\.rh7\.(collector-runner|audit)'
+  else
+    crontab -l 2>/dev/null | grep -qE 'fleet-audit|collector-runner|audit-device\.sh'
+  fi
+}
 scheduled=false
-if [[ "$OS" == "Darwin" ]]; then
-  # collector-runner supersedes the direct audit agent; either counts as scheduled
-  if launchctl list 2>/dev/null | grep -qE 'com\.rh7\.(collector-runner|audit)'; then scheduled=true; fi
-else
-  if crontab -l 2>/dev/null | grep -qE 'fleet-audit|collector-runner|audit-device\.sh'; then scheduled=true; fi
-fi
+schedule_installed && scheduled=true
 $scheduled && ok "Daily audit schedule: installed" || warn "Daily audit schedule: not installed"
 
 # ── 4. Is this host already reporting? ─────────────────────────────────────
@@ -193,6 +198,10 @@ else
   echo; info "Not yet enrolled — running the first audit and installing the daily schedule…"
   run_audit --run-and-install
 fi
+# Re-check the schedule after the run: the audit script installs cron at the end,
+# and a failure there must NOT be reported as a healthy enrollment (see #6).
+scheduled=false
+schedule_installed && scheduled=true
 
 # ── 5. Post-flight: confirm the device actually landed, then role/age follow-ups ──
 # The read-back is authoritative: if the host isn't in the registry after the
@@ -231,4 +240,16 @@ else
   ok "age key registered"
 fi
 echo
-ok "${BOLD}Done.${NC} ${HOST} is enrolled and reporting; the daily audit keeps it current."
+if $scheduled; then
+  ok "${BOLD}Done.${NC} ${HOST} is enrolled and reporting; the daily audit keeps it current."
+elif [[ "$MODE" == "status" ]]; then
+  warn "${BOLD}Enrolled, but no daily audit schedule is installed.${NC} Re-run without --status to install it."
+else
+  # The audit uploaded, but the recurring schedule did NOT install — don't claim
+  # "the daily audit keeps it current", or the host silently goes stale.
+  err "${BOLD}Enrolled, but the daily audit schedule did NOT install.${NC} ${HOST} uploaded an audit,"
+  err "but without a schedule it will go stale. See the audit run's messages above for the cause."
+  [[ "$OS" != "Darwin" ]] && err "Check cron:  command -v crontab || echo 'cron not installed'; systemctl status cron 2>/dev/null || true"
+  err "Then retry:  curl -fsSL config.rh7labs.com/enroll | bash -s -- --force"
+  exit 1
+fi


### PR DESCRIPTION
Fixes #37.

## Problem

`curl -fsSL config.rh7labs.com/enroll | bash` on a **server-role** device (e.g. `vmi1643059`) uploads the audit but **silently never installs the daily schedule**, then prints `✓ Done… the daily audit keeps it current`. Re-running repeats the same broken step forever, so the host goes stale with no signal.

## Root cause — three `set -euo pipefail` defects

1. **`show_checklist` aborts the audit run.** `checklist=$(curl -sf .../api/fleet/checklist/$role …)` — for `role=server` the service returns **HTTP 400** (`Unknown role: server`; checklist roles are only `workstation(-mac)`/`personal(-mac)`), so `curl -sf` exits 22 and `set -e` kills the script. `install_cron` runs *right after* `show_checklist`, so scheduling is skipped. Affects every `server`/`unknown` role device.
2. **`install_crontab` aborts on an empty crontab.** `(crontab -l | grep -v … ; echo) | crontab -` — on a fresh box the `grep -v` matches nothing (exit 1) and `set -e` kills the subshell before the `echo`, so the new line is never written. (Latent; `vmi1643059`'s crontab wasn't empty, so it only hit #1.)
3. **`enroll.sh` reports success unconditionally** — it verifies the *device* landed but never the *schedule*, and the final "Done" prints regardless.

## Fix

**`scripts/audit-device.sh`**
- `show_checklist`: `|| true` on the checklist `curl -sf` and the role fetch — it's cosmetic and must never abort enrollment.
- Reorder the `--run-and-install` arm: run `install_cron` (critical) **before** `show_checklist` (cosmetic), and guard it (`install_cron || warn …`) so a failed install warns instead of aborting.
- `install_crontab`: read the existing crontab with `|| true` (empty crontab can't abort), then append; **fail loud** if `crontab` is missing or the write fails.

**`scripts/enroll.sh`**
- Refactor schedule detection into `schedule_installed()`, re-check **after** the audit run, and refuse to claim "the daily audit keeps it current" if it didn't install — loud error + non-zero exit + `--force` retry hint.

## Verification

`bash -n` on both scripts, plus the fixed functions extracted verbatim and exercised under `set -euo pipefail`:
- ✅ empty crontab → `# fleet-audit` line written (was: silent abort)
- ✅ existing entries preserved (the exact `vmi1643059` case) + fleet-audit added
- ✅ idempotent re-run → no duplicate entry
- ✅ `show_checklist` survives a 400 checklist without aborting

## Deploy

No separate deploy — `config.rh7labs.com/{enroll,audit}` rewrite to these `@main` scripts, so merging makes the fix live fleet-wide (after raw.githubusercontent's ~5-min cache). Re-running `enroll` on `vmi1643059` will then install the schedule with no manual steps.

## Possible follow-up (separate repo)

`rh-device-management`: `GET /api/fleet/checklist/:role` could return an empty checklist (200) for known-but-checklist-less roles like `server` instead of 400, as defense-in-depth. The client fix here is the definitive one.
