### PR TITLE
fix(enroll): run audit from a file (not curl|bash) + set role at enroll

### DIFF
--- a/scripts/audit-device.sh
+++ b/scripts/audit-device.sh
@@ -132,7 +132,11 @@ build_audit_cmd() {
   if [[ -f "$HOME/dotfiles/scripts/audit-device.sh" ]]; then
     echo "bash $HOME/dotfiles/scripts/audit-device.sh --run"
   else
-    echo "curl -fsSL $SCRIPT_URL | bash -s -- --run"
+    # Download-then-exec, NOT `curl … | bash`: under a pipe stdin is the script,
+    # and a collector that reads stdin consumes the rest of it — truncating the
+    # audit before it uploads (the no-clone daily audit would silently do
+    # nothing). Running from a temp file avoids it (mirrors enroll.sh run_audit).
+    echo "t=\"\$(mktemp)\" && curl -fsSL $SCRIPT_URL -o \"\$t\" && bash \"\$t\" --run; rm -f \"\$t\""
   fi
 }
 

--- a/scripts/enroll.sh
+++ b/scripts/enroll.sh
@@ -13,6 +13,9 @@
 # Flags:
 #   --status   check only; make no changes (report tailscale + audit state)
 #   --force    (re)run the audit and reinstall the schedule even if healthy
+#   --role R   set this device's fleet role so security posture is graded right
+#              (personal|developer|server|ai-inference|smart-home|mobile);
+#              also honors ROLE=R in the environment. Omit to leave it unchanged.
 #
 # The heavy lifting (inventory + registration + scheduling) lives in
 # audit-device.sh; this is just the safe, idempotent front-door around it.
@@ -27,14 +30,23 @@ HOST="$(hostname | sed 's/\.local$//')"
 AUDIT_URL="https://config.rh7labs.com/audit"
 LOCAL_AUDIT="$HOME/dotfiles/scripts/audit-device.sh"
 
-MODE="${1:-run}"
-MODE="${MODE//[$'\t\r\n ']/}"   # tolerate paste artifacts on the flag
-case "$MODE" in
-  run|--run|"") MODE="run" ;;
-  --status|status) MODE="status" ;;
-  --force|force) MODE="force" ;;
-  *) echo "usage: enroll.sh [--status | --force]" >&2; exit 2 ;;
-esac
+# One positional mode (run|--status|--force) plus an optional role. Role may come
+# from the environment (ROLE=server curl…|bash) or a flag (--role server); it's
+# applied to the device record after the audit (see post-flight below), so
+# posture is set at enroll instead of hand-PATCHed afterwards.
+MODE="run"
+ROLE="${ROLE:-}"
+while [[ $# -gt 0 ]]; do
+  arg="${1//[$'\t\r\n ']/}"   # tolerate paste artifacts on flags
+  case "$arg" in
+    --role=*) ROLE="${arg#--role=}"; shift ;;
+    --role)   ROLE="${2:-}"; shift; [[ $# -gt 0 ]] && shift ;;
+    run|--run|"") MODE="run"; shift ;;
+    --status|status) MODE="status"; shift ;;
+    --force|force) MODE="force"; shift ;;
+    *) echo "usage: enroll.sh [--status | --force] [--role <role>]" >&2; exit 2 ;;
+  esac
+done
 
 # ── Colors / helpers ───────────────────────────────────────────────────────
 if [[ -t 1 ]]; then
@@ -178,8 +190,22 @@ run_audit() {  # run_audit MODE_FLAG
     info "Running: audit-device.sh ${flag} (local checkout)"
     bash "$LOCAL_AUDIT" "$flag"
   else
-    info "Running: curl config.rh7labs.com/audit | bash -s -- ${flag}"
-    curl -fsSL "$AUDIT_URL" | bash -s -- "$flag"
+    # Download-then-exec, NOT `curl … | bash`: the audit script's collectors
+    # shell out to commands that read stdin, and under `curl | bash` stdin *is*
+    # the script pipe — so a collector consumes the rest of the script and
+    # truncates the run before it uploads/registers/schedules. That silently
+    # half-enrolls every no-clone host (audit built, never sent). Running from a
+    # file makes stdin the terminal, so the collectors can't eat the script.
+    info "Running: audit-device.sh ${flag} (fetched)"
+    local tmp rc
+    tmp="$(mktemp)" || { err "mktemp failed"; return 1; }
+    if curl -fsSL "$AUDIT_URL" -o "$tmp"; then
+      bash "$tmp" "$flag"; rc=$?
+    else
+      err "Failed to download the audit script from ${AUDIT_URL}"; rc=1
+    fi
+    rm -f "$tmp"
+    return $rc
   fi
 }
 
@@ -226,12 +252,34 @@ if [[ -z "$dev_json" || "$dev_json" == *'"error"'* ]]; then
   exit 1
 fi
 
+# If a role was supplied (--role / ROLE=…), apply it now that the audit has
+# created the device row. Validated against the roles the config service actually
+# grades on; applied via PATCH (404s only if the device is absent, which it isn't
+# post-audit). No role supplied → the stored role is left untouched (the audit
+# preserves it), and the unknown-role hint below still fires.
+if [[ -n "$ROLE" && "$MODE" != "status" ]]; then
+  role_want="$(printf '%s' "$ROLE" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  case " personal developer server ai-inference smart-home mobile " in
+    *" $role_want "*)
+      if curl -sf -X PATCH "${CONFIG_URL}/api/devices/${HOST}" \
+           -H 'content-type: application/json' \
+           -d "{\"role\":\"${role_want}\"}" --max-time 5 >/dev/null 2>&1; then
+        ok "role set to '${role_want}'"
+        dev_json="$(read_device)"   # refresh so the summary reflects it
+      else
+        warn "could not set role to '${role_want}' (PATCH failed) — set it later by hand"
+      fi ;;
+    *)
+      warn "ignoring role '${ROLE}': not one of personal/developer/server/ai-inference/smart-home/mobile" ;;
+  esac
+fi
+
 role="$(printf '%s' "$dev_json" | json_field role)"
 echo "${BOLD}Fleet status for ${HOST}:${NC}"
 case "$role" in
   ""|unknown)
     warn "role=${role:-unknown} — set it so security posture is graded correctly (e.g. server):"
-    echo "     curl -X PATCH ${CONFIG_URL}/api/devices/${HOST} -H 'content-type: application/json' -d '{\"role\":\"server\"}'" ;;
+    echo "     curl -fsSL config.rh7labs.com/enroll | bash -s -- --role server   (or PATCH /api/devices/${HOST})" ;;
   *) ok "role=${role}" ;;
 esac
 if printf '%s' "$dev_json" | json_is_null age_public_key; then


### PR DESCRIPTION
## What & why

Found while re-enrolling the three OrbStack VMs (`dev-vm` / `hermes-lab` / `nix-lab`) — all three were **half-enrolled**: an audit had uploaded (or not) but the daily schedule never installed.

### 1. `curl | bash` stdin truncation — the real bug

The audit script builds its JSON by running ~30 collectors as `$(collect_*)` command substitutions. Some collectors shell out to commands that read **stdin**. Under `curl … | bash`, **stdin *is* the script pipe**, so a collector consumes the rest of the script mid-run. The audit JSON gets fully assembled, but the `upload → register → install_cron` code that follows is never reached — bash hits EOF and exits 0. The host silently half-enrolls.

This hit **every no-clone Linux host**, and — because the generated **cron line** and the standalone `config.rh7labs.com/audit | bash` use the same pipe — it would also truncate **daily audits**.

**Fix:** `enroll.sh`'s `run_audit` and the cron line emitted by `build_audit_cmd` now **download-then-exec** (run from a temp file), so stdin is the terminal, not the script.

Reproduced + verified live on all three VMs — with the pipe they die right after `Auditing…`; from a file they upload, register, and install the cron.

### 2. `--role` at enroll

`enroll.sh --role <role>` (or `ROLE=…` in the env) now **applies** the device's fleet role via `PATCH /api/devices/:host` after the audit, instead of only printing a "run this curl by hand" hint. Validated against the roles the config service actually grades on (`personal|developer|server|ai-inference|smart-home|mobile`); omitting it leaves the stored role untouched (the audit preserves it). Verified: `dev-vm` enrolled straight to `role=developer`.

## Verification
- `bash -n` on both scripts ✓
- Arg parser unit-tested: `--role x`, `--role=x`, `ROLE=x` env, `--force --role x`, missing-value (no infinite loop), bogus → exit 2 ✓
- Generated cron command passes `sh -n`; literal `$(mktemp)`/`$t`, expanded URL ✓
- End-to-end: edited `enroll.sh --force --role developer` on dev-vm → uploaded → registered → cron installed → `role=developer` → Done ✓
- All three VMs now in the registry with fresh `last_seen` + a `fleet-audit` cron entry ✓

## Not in scope (follow-up)
Standalone, human-run `config.rh7labs.com/audit | bash` still uses `curl|bash` and remains subject to the truncation. A root-cause fix (self-reexec guard, or fixing the specific stdin-reading collector) can make that path safe too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)