### PR TITLE
fix(enroll): detach audit child's stdin so piped enroll keeps its post-flight

### DIFF
--- a/scripts/enroll.sh
+++ b/scripts/enroll.sh
@@ -186,21 +186,27 @@ fi
 # ── Decide ─────────────────────────────────────────────────────────────────
 run_audit() {  # run_audit MODE_FLAG
   local flag="$1"
+  # `</dev/null` on the audit invocation is load-bearing. The audit's collectors
+  # read stdin; when *enroll itself* is run via `curl … | bash`, the child audit
+  # inherits enroll's pipe as its stdin, so a collector consumes the rest of the
+  # ENROLL script — truncating enroll's own post-flight (the role apply and the
+  # #38 fail-loud registry read-back). Detaching the child's stdin prevents it
+  # from reaching back into the parent's pipe.
   if [[ -f "$LOCAL_AUDIT" ]]; then
     info "Running: audit-device.sh ${flag} (local checkout)"
-    bash "$LOCAL_AUDIT" "$flag"
+    bash "$LOCAL_AUDIT" "$flag" </dev/null
   else
     # Download-then-exec, NOT `curl … | bash`: the audit script's collectors
     # shell out to commands that read stdin, and under `curl | bash` stdin *is*
     # the script pipe — so a collector consumes the rest of the script and
     # truncates the run before it uploads/registers/schedules. That silently
     # half-enrolls every no-clone host (audit built, never sent). Running from a
-    # file makes stdin the terminal, so the collectors can't eat the script.
+    # file (with stdin detached) makes the collectors read nothing to eat.
     info "Running: audit-device.sh ${flag} (fetched)"
     local tmp rc
     tmp="$(mktemp)" || { err "mktemp failed"; return 1; }
     if curl -fsSL "$AUDIT_URL" -o "$tmp"; then
-      bash "$tmp" "$flag"; rc=$?
+      bash "$tmp" "$flag" </dev/null; rc=$?
     else
       err "Failed to download the audit script from ${AUDIT_URL}"; rc=1
     fi


### PR DESCRIPTION
## Follow-up to #39

#39 fixed the audit truncating itself under `curl|bash` by running it from a temp file. But that surfaced a second face of the same stdin problem, one layer up.

**Symptom:** `curl … | bash -s -- --force` on a no-clone host uploads + schedules correctly, but enroll's output stops right after the audit — no `Fleet status` / `Done`, and `--role` is silently not applied.

**Cause:** `run_audit` runs `bash "$tmp"`. When *enroll itself* is the piped script, that child inherits **enroll's pipe** as stdin, so an audit collector that reads stdin consumes the rest of the *enroll* script — eating enroll's post-flight (the `--role` PATCH and the #38 fail-loud registry read-back). It only showed up under `curl|enroll|bash`; running enroll from a file (a dotfiles checkout) was unaffected, which is why #39's file-based test didn't catch it.

**Fix:** `</dev/null` on both audit invocations (local + fetched) so the child audit never reaches back into the parent's pipe.

## Verification
Reproduced the exact `curl|enroll|bash` shape by piping the script into `bash -s`:
```
orb -m nix-lab bash -s -- --force --role developer < scripts/enroll.sh
```
- **Before:** truncates right after `→ t="$(mktemp)"…`, no post-flight.
- **After:** full post-flight — `role set to 'developer'` → `Fleet status` → `Done`; registry confirms `nix-lab role=developer`.
- `bash -n` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)