### PR TITLE
fix(audit): self-reexec guard so `curl … | bash` audit doesn't truncate (rh7/rh-device-management#217)

### DIFF
--- a/scripts/audit-device.sh
+++ b/scripts/audit-device.sh
@@ -34,6 +34,26 @@ SCRIPT_URL="https://config.rh7labs.com/audit"
 CRON_TAG="# fleet-audit"
 OLD_CRON_TAG="# fleet-heartbeat"
 
+# ── Self-reexec guard: survive `curl … | bash` (#217) ──
+# Under a pipe, fd 0 (stdin) *is* this script. Several collectors below shell out
+# to commands that read stdin, which consume the not-yet-executed remainder of
+# THIS script — so bash hits EOF and exits 0 *before* the upload/register/schedule
+# code runs, leaving a silent half-audit (JSON built, never sent). If we're being
+# read from a pipe (stdin is not a tty AND there is no real script file on disk),
+# re-fetch ourselves to a temp file and exec from there with stdin detached, so no
+# collector can eat the script:
+#   • `bash file` / cron's `bash "$t"`          → BASH_SOURCE[0] is a real file → skip
+#   • enroll's temp-file wrapper (`bash "$t" </dev/null`) → real file          → skip
+#   • `curl … | bash -s`                        → BASH_SOURCE[0] empty/not-file → re-exec
+# Fails soft: if the self-fetch (or mktemp) fails, fall through to the piped path,
+# no worse than today. AUDIT_REEXEC prevents any re-exec loop.
+if [[ -z "${AUDIT_REEXEC:-}" && ! -t 0 && ! -f "${BASH_SOURCE[0]:-/nonexistent}" ]]; then
+  if _self="$(mktemp 2>/dev/null)" && curl -fsSL "$SCRIPT_URL" -o "$_self" 2>/dev/null && [[ -s "$_self" ]]; then
+    AUDIT_REEXEC=1 exec bash "$_self" "$@" </dev/null
+  fi
+  [[ -n "${_self:-}" ]] && rm -f "$_self"   # couldn't self-fetch — fall through
+fi
+
 # ── Colors ──
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
## Summary
Makes `audit-device.sh` safe under `curl … | bash`. Under a pipe, fd 0 (stdin) **is** the script; several collectors shell out to commands that read stdin and consume the not-yet-executed remainder of the script — so bash hits EOF and exits 0 **before** the upload/register/schedule code, leaving a **silent half-audit** (JSON built, never sent). Diagnosed live on the OrbStack VMs (dev-vm / hermes-lab / nix-lab).

The enroll path was already fixed (dotfiles#39/#40) by *wrapping* the audit in a temp-file run; the **standalone** `curl … | bash` path documented in the audit shortlink still had nothing wrapping it. This guard makes the script self-safe regardless of how it's invoked.

## Fix
A self-reexec guard right after the config block: if invoked from a pipe (stdin not a tty **and** no real script file on disk), re-fetch to a temp file and `exec` from there with stdin detached (`</dev/null`), so no collector can eat the script.

- `bash file` / cron's `bash "$t"` → `BASH_SOURCE[0]` is a real file → **skipped** (no extra fetch, no double-run).
- enroll's temp-file wrapper (`bash "$t" </dev/null`) → real file → **skipped**.
- `curl … | bash -s` → `BASH_SOURCE[0]` empty/not-a-file → **re-exec**.
- **Fails soft:** a failed self-fetch or `mktemp` falls through to the piped path (no worse than today). `AUDIT_REEXEC` prevents any re-exec loop.

## Verification
Reproduced the bug and proved the fix with a faithful mock (a `$(cat)` "collector" that drains stdin):

| Invocation | Without guard | With guard |
|---|---|---|
| piped (`curl \| bash`) | ❌ truncates after PHASE-1, upload never reached | ✅ both phases, PHASE-1 prints **once** |
| `bash file </dev/null` (cron/enroll) | ✅ | ✅ guard skipped, **no re-fetch** |
| `mktemp` fails (unwritable TMPDIR) | — | ✅ falls through, no hard-abort |

- Detection logic (`BASH_SOURCE[0]` + `-t 0`) checked across all invocation modes.
- `bash -n` clean; `shellcheck` clean for the new region (only a pre-existing, unrelated SC2034 at line ~2216 remains).
- Bare `mktemp` verified portable (BSD/macOS + GNU/Linux).

## Acceptance criteria (rh7/rh-device-management#217)
- [x] `curl … | bash -s -- --run` reaches the upload/register code (proven via reproduction)
- [x] `bash scripts/audit-device.sh --run` (file path) unaffected — guard skipped, no extra fetch, no double-run
- [x] Cron daily line unaffected (runs from a real file)
- [x] `bash -n` clean

## Issue
Refs rh7/rh-device-management#217 — the issue lives in the control-plane repo. GitHub can't auto-close cross-repo via keyword, so it will be **closed manually** once this merges and the `config.rh7labs.com/audit` shortlink serves the fixed script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)