### PR TITLE
Collect configuration drift in fleet audits

### DIFF
--- a/scripts/audit-config-drift.sh
+++ b/scripts/audit-config-drift.sh
@@ -6,6 +6,7 @@
 # Usage:
 #   ./scripts/audit-config-drift.sh                  # audit vs declared config
 #   ./scripts/audit-config-drift.sh Kassie-M5-Air13  # audit a specific host
+#   ./scripts/audit-config-drift.sh --json            # structured fleet payload
 #   ./scripts/audit-config-drift.sh --snapshot       # save baseline of all defaults
 #   ./scripts/audit-config-drift.sh --diff           # diff current state vs baseline
 #
@@ -18,9 +19,11 @@ set -euo pipefail
 
 ACTION="audit"
 HOST=""
+JSON_OUTPUT=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --json)     JSON_OUTPUT=true; shift ;;
     --snapshot) ACTION="snapshot"; shift ;;
     --diff)     ACTION="diff"; shift ;;
     -h|--help)  sed -n '2,15p' "$0"; exit 0 ;;
@@ -35,27 +38,78 @@ SNAPSHOT_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/dotfiles-audit"
 SNAPSHOT_FILE="$SNAPSHOT_DIR/baseline-$HOST.txt"
 DRIFT=0
 # Track drift direction separately so callers can distinguish risky from benign:
-#   RISKY  = `+` items: present locally, not in config → 'switch' WILL overwrite.
-#   BENIGN = `-` items: in config, not present locally → 'switch' WILL apply.
+#   RISKY         = actual state that `switch` WILL overwrite.
+#   BENIGN        = declared state not present locally; `switch` WILL apply it.
+#   INFORMATIONAL = undeclared state preserved by the current cleanup policy.
 RISKY=0
 BENIGN=0
+INFORMATIONAL=0
+CURRENT_SECTION=""
+JSON_ITEMS='[]'
+
+fail() {
+  local reason="$1"
+  if $JSON_OUTPUT && command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import json,sys; print(json.dumps({"supported": False, "status": "error", "host": sys.argv[1], "reason": sys.argv[2]}))' "$HOST" "$reason"
+  else
+    echo "$reason" >&2
+  fi
+  exit 2
+}
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
-  echo "macOS only." >&2; exit 2
+  fail "macOS only."
 fi
 if ! command -v jq >/dev/null; then
-  echo "jq not found (install via 'brew install jq')." >&2; exit 2
+  fail "jq not found (install via 'brew install jq')."
 fi
 if [[ "$ACTION" == "audit" ]] && ! command -v nix >/dev/null; then
-  echo "nix not found." >&2; exit 2
+  fail "nix not found."
+fi
+if [[ "$ACTION" == "audit" ]] && ! nix eval --json \
+  "$FLAKE_DIR#darwinConfigurations.\"$HOST\".config.system.primaryUser" >/dev/null 2>&1; then
+  fail "unable to evaluate nix-darwin configuration for $HOST"
 fi
 
 # ── Output helpers ────────────────────────────────────────────────────
-heading() { printf "\n\033[1;36m== %s ==\033[0m\n" "$*"; }
-ok()      { printf "  \033[32m✓\033[0m %s\n" "$*"; }
-add()     { printf "  \033[33m+\033[0m %s\n" "$*"; DRIFT=1; RISKY=$((RISKY+1)); }
-sub()     { printf "  \033[31m-\033[0m %s\n" "$*"; DRIFT=1; BENIGN=$((BENIGN+1)); }
-note()    { printf "  \033[90m· %s\033[0m\n" "$*"; }
+record_item() {
+  local classification="$1" direction="$2" message="$3"
+  JSON_ITEMS=$(jq -c \
+    --arg section "$CURRENT_SECTION" \
+    --arg classification "$classification" \
+    --arg direction "$direction" \
+    --arg message "$message" \
+    '. + [{section: $section, classification: $classification, direction: $direction, message: $message}]' \
+    <<<"$JSON_ITEMS")
+}
+heading() {
+  CURRENT_SECTION="$*"
+  $JSON_OUTPUT || printf "\n\033[1;36m== %s ==\033[0m\n" "$*"
+}
+ok() {
+  $JSON_OUTPUT || printf "  \033[32m✓\033[0m %s\n" "$*"
+}
+add() {
+  local message="$*"
+  $JSON_OUTPUT || printf "  \033[33m+\033[0m %s\n" "$message"
+  DRIFT=1; RISKY=$((RISKY+1))
+  record_item "risky" "actual_differs" "$message"
+}
+sub() {
+  local message="$*"
+  $JSON_OUTPUT || printf "  \033[31m-\033[0m %s\n" "$message"
+  DRIFT=1; BENIGN=$((BENIGN+1))
+  record_item "benign" "declared_not_present" "$message"
+}
+observe() {
+  local message="$*"
+  $JSON_OUTPUT || printf "  \033[36m·\033[0m %s\n" "$message"
+  DRIFT=1; INFORMATIONAL=$((INFORMATIONAL+1))
+  record_item "informational" "present_not_declared" "$message"
+}
+note() {
+  $JSON_OUTPUT || printf "  \033[90m· %s\033[0m\n" "$*"
+}
 
 # Evaluate an attribute of the host's darwinConfiguration as JSON.
 # Returns empty string on failure (option may not be set).
@@ -88,7 +142,7 @@ eval_casks() {
 eval_mas_ids() {
   eval_json "system.activationScripts.postActivation.text" \
     | jq -r 'if type=="string" then . else empty end' 2>/dev/null \
-    | grep -oE 'mas_install [0-9]+' | awk '{print $2}' | sort -u
+    | grep -oE 'mas_install [0-9]+' | awk '{print $2}' | sort -u || true
 }
 
 # ── Snapshot/diff support ─────────────────────────────────────────────
@@ -185,7 +239,7 @@ if [[ "$ACTION" == "diff" ]]; then
   exit 1
 fi
 
-echo "Auditing $HOST against $FLAKE_DIR ..."
+$JSON_OUTPUT || echo "Auditing $HOST against $FLAKE_DIR ..."
 
 # ── Dock drift ────────────────────────────────────────────────────────
 heading "Dock"
@@ -206,22 +260,30 @@ else
     ok "dock matches config exactly"
   elif [[ -z "$added$removed" ]]; then
     note "same items, different order — declared:"
-    echo "$declared_dock" | sed 's/^/    /'
+    $JSON_OUTPUT || echo "$declared_dock" | sed 's/^/    /'
     note "actual:"
-    echo "$actual_dock" | sed 's/^/    /'
-    DRIFT=1
-    RISKY=$((RISKY+1))   # switch will overwrite manual reorder
+    $JSON_OUTPUT || echo "$actual_dock" | sed 's/^/    /'
+    add "Dock contains the declared items in a different order"
   fi
 fi
 
 # ── Cask drift ────────────────────────────────────────────────────────
 heading "Homebrew casks"
 declared_casks=$(eval_casks | sort -u)
-installed_casks=$(brew list --cask 2>/dev/null | sort -u)
+installed_casks=$( { brew list --cask 2>/dev/null || true; } | sort -u)
 
 orphan=$(comm -23 <(echo "$installed_casks") <(echo "$declared_casks"))
 missing=$(comm -13 <(echo "$installed_casks") <(echo "$declared_casks"))
-[[ -n "$orphan"  ]] && while read -r c; do add "$c (installed, not declared)"; done <<<"$orphan"
+cleanup_mode=$(eval_str "homebrew.onActivation.cleanup")
+if [[ -n "$orphan" ]]; then
+  while read -r c; do
+    if [[ "$cleanup_mode" == "zap" || "$cleanup_mode" == "uninstall" ]]; then
+      add "$c (installed, not declared; cleanup=$cleanup_mode will remove it)"
+    else
+      observe "$c (installed, not declared; cleanup=${cleanup_mode:-none} preserves it)"
+    fi
+  done <<<"$orphan"
+fi
 [[ -n "$missing" ]] && while read -r c; do sub "$c (declared, not installed)"; done <<<"$missing"
 [[ -z "$orphan$missing" ]] && ok "all casks match"
 
@@ -245,17 +307,18 @@ declare -A PKG_CASK_APPS=(
 # but are still "expected" — keep them out of the orphan-app warning.
 MANUAL_APPS=(
   "ExpressVPN.app"  # cask installer helper needs GUI auth — install via `brew install --cask expressvpn`
+  "Private Internet Access.app"  # retained manually; Homebrew cask has quarantine issues
 )
 
 # ── Mac App Store drift ───────────────────────────────────────────────
 heading "Mac App Store apps"
 declared_mas=$(eval_mas_ids)
-installed_mas_raw=$(mas list 2>/dev/null | awk '{print $1}' | sort -u)
+installed_mas_raw=$( { mas list 2>/dev/null || true; } | awk '{print $1}' | sort -u)
 # Filter out Apple stock apps from "installed" so they don't show as drift.
 installed_mas=$(comm -23 <(echo "$installed_mas_raw") <(echo "$APPLE_STOCK_MAS_IDS" | tr ' ' '\n' | sort -u))
 
 # Cache mas list output so we can resolve names cheaply.
-mas_list_cache=$(mas list 2>/dev/null)
+mas_list_cache=$(mas list 2>/dev/null || true)
 mas_name() {
   echo "$mas_list_cache" | awk -v i="$1" '$1==i{$1=""; sub(/^ /,""); sub(/  *\(.*\)$/,""); print}'
 }
@@ -267,7 +330,7 @@ else
   missing=$(comm -13 <(echo "$installed_mas") <(echo "$declared_mas"))
   while read -r id; do
     [[ -z "$id" ]] && continue
-    add "MAS $id $(mas_name "$id") (installed, not declared)"
+    observe "MAS $id $(mas_name "$id") (installed, not declared; activation does not remove it)"
   done <<<"$orphan"
   while read -r id; do
     [[ -z "$id" ]] && continue
@@ -288,7 +351,7 @@ APPLE_APPS_RE='^(Safari|GarageBand|iMovie|Keynote|Numbers|Pages|Utilities|Nix Ap
 expected_apps=""
 for c in $declared_casks; do
   # Handle direct ".app (App)" artifacts AND "Installer.app -> Real.app (App)" rename arrows.
-  apps=$(brew info --cask "$c" 2>/dev/null \
+  apps=$({ brew info --cask "$c" 2>/dev/null || true; } \
     | awk '/^==> Artifacts/{flag=1; next} /^==>/{flag=0}
            flag && /\.app \(App\)$/ {
              line=$0
@@ -323,7 +386,7 @@ for app in /Applications/*.app; do
   name=$(basename "$app")
   echo "$name" | grep -qE "$APPLE_APPS_RE" && continue
   echo "$expected_apps" | grep -qxF "$name" && continue
-  add "$app"
+  observe "$app (unmanaged application; switch does not remove it)"
   unknown_count=$((unknown_count + 1))
 done
 [[ $unknown_count -eq 0 ]] && ok "all /Applications entries accounted for"
@@ -361,19 +424,41 @@ for line in "${checks[@]}"; do
 done
 
 # ── Summary ───────────────────────────────────────────────────────────
-echo
+$JSON_OUTPUT || echo
 # Machine-readable summary line — callers (e.g. rebuild.sh) parse this to
 # distinguish risky drift (manual changes that 'switch' would overwrite)
 # from benign drift (declared items not yet applied — 'switch' just applies them).
-echo "DRIFT_RESULT: risky=$RISKY benign=$BENIGN"
+if $JSON_OUTPUT; then
+  if [[ $RISKY -gt 0 ]]; then
+    status="risky"
+  elif [[ $BENIGN -gt 0 ]]; then
+    status="benign"
+  elif [[ $INFORMATIONAL -gt 0 ]]; then
+    status="informational"
+  else
+    status="clean"
+  fi
+  jq -n \
+    --arg host "$HOST" \
+    --arg flake_ref "$FLAKE_DIR#$HOST" \
+    --arg checked_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg status "$status" \
+    --argjson risky "$RISKY" \
+    --argjson benign "$BENIGN" \
+    --argjson informational "$INFORMATIONAL" \
+    --argjson items "$JSON_ITEMS" \
+    '{supported: true, host: $host, flake_ref: $flake_ref, checked_at: $checked_at, status: $status, risky_count: $risky, benign_count: $benign, informational_count: $informational, items: $items}'
+else
+  echo "DRIFT_RESULT: risky=$RISKY benign=$BENIGN informational=$INFORMATIONAL"
+fi
 
 if [[ $DRIFT -eq 0 ]]; then
-  printf "\033[1;32mNo drift detected.\033[0m\n"
+  $JSON_OUTPUT || printf "\033[1;32mNo drift detected.\033[0m\n"
   exit 0
 elif [[ $RISKY -eq 0 ]]; then
-  printf "\033[1;36mOnly benign drift (%d declared item(s) pending) — 'switch' will apply.\033[0m\n" "$BENIGN"
+  $JSON_OUTPUT || printf "\033[1;36mNon-destructive drift: %d declared item(s) pending, %d informational item(s) preserved.\033[0m\n" "$BENIGN" "$INFORMATIONAL"
   exit 1
 else
-  printf "\033[1;33mRisky drift detected — %d manual change(s) will be overwritten by 'switch'. Review above.\033[0m\n" "$RISKY"
+  $JSON_OUTPUT || printf "\033[1;33mRisky drift detected — %d manual change(s) will be overwritten by 'switch'. Review above.\033[0m\n" "$RISKY"
   exit 1
 fi

--- a/scripts/audit-device.sh
+++ b/scripts/audit-device.sh
@@ -24,6 +24,10 @@ set -euo pipefail
 HOSTNAME="$(hostname | sed 's/\.local$//')"
 OS="$(uname -s)"
 ARCH="$(uname -m)"
+# Scheduled jobs do not inherit the interactive shell's Nix/Homebrew paths.
+# Normalize them before collection so casks, MAS apps, and host config evaluation
+# do not silently report "not installed" on otherwise-managed Macs.
+export PATH="/etc/profiles/per-user/$(id -un)/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
 MODE="${1:-interactive}"
 # Be forgiving of copy-paste artifacts on the mode arg: a trailing CR/space/tab
 # (common when the curl|bash one-liner is pasted) would otherwise leave MODE as
@@ -464,6 +468,27 @@ try:
     print(json.dumps(apps))
 except: print('[]')
 "
+}
+
+collect_config_drift() {
+  if [[ "$OS" != "Darwin" ]]; then
+    echo '{"supported":false,"status":"unavailable","reason":"macOS only"}'
+    return
+  fi
+
+  local drift_script="${DOTFILES:-$HOME/dotfiles}/scripts/audit-config-drift.sh"
+  if [[ ! -x "$drift_script" ]]; then
+    echo '{"supported":false,"status":"unavailable","reason":"audit-config-drift.sh not found in dotfiles checkout"}'
+    return
+  fi
+
+  local result
+  result=$(run_timeout 180 "$drift_script" --json "$HOSTNAME" 2>/dev/null || true)
+  if [[ -n "$result" ]] && python3 -c 'import json,sys; json.load(sys.stdin)' <<<"$result" 2>/dev/null; then
+    echo "$result"
+  else
+    echo '{"supported":false,"status":"error","reason":"config drift audit failed or returned invalid JSON"}'
+  fi
 }
 
 collect_cli_tools() {
@@ -2176,6 +2201,8 @@ $(collect_applications)
 $(collect_macos_defaults)
 ---SECTION: dock_apps
 $(collect_dock_apps)
+---SECTION: config_drift
+$(collect_config_drift)
 ---SECTION: cli_tools
 $(collect_cli_tools)
 ---SECTION: node_globals

--- a/scripts/collector-runner.sh
+++ b/scripts/collector-runner.sh
@@ -45,6 +45,7 @@ OS="$(uname -s)"
 CACHE="$CACHE_DIR/$COLLECTOR"
 RUNNER_SELF="$CACHE_DIR/collector-runner.sh"
 LOG="$CACHE_DIR/runner.log"
+AGENT_PATH="/etc/profiles/per-user/$(id -un)/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
 mkdir -p "$CACHE_DIR"
 log() { echo "$(date -u +%FT%TZ) collector-runner: $*" | tee -a "$LOG" >&2; }
@@ -171,7 +172,7 @@ install_schedule() {
     <key>StartCalendarInterval</key>
     <dict><key>Hour</key><integer>${hour}</integer><key>Minute</key><integer>${minute}</integer></dict>
     <key>EnvironmentVariables</key>
-    <dict><key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string></dict>
+    <dict><key>PATH</key><string>${AGENT_PATH}</string></dict>
     <key>StandardOutPath</key><string>/tmp/${LABEL}.out.log</string>
     <key>StandardErrorPath</key><string>/tmp/${LABEL}.err.log</string>
     <key>RunAtLoad</key><false/>

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -110,9 +110,11 @@ if [[ -x "$DOTFILES_DIR/scripts/audit-config-drift.sh" ]]; then
   # Parse risky/benign counts from audit's machine-readable summary line.
   risky=$(grep -E "^DRIFT_RESULT:" "$audit_log" | sed -nE 's/.*risky=([0-9]+).*/\1/p')
   benign=$(grep -E "^DRIFT_RESULT:" "$audit_log" | sed -nE 's/.*benign=([0-9]+).*/\1/p')
+  informational=$(grep -E "^DRIFT_RESULT:" "$audit_log" | sed -nE 's/.*informational=([0-9]+).*/\1/p')
   rm -f "$audit_log"
   risky=${risky:-0}
   benign=${benign:-0}
+  informational=${informational:-0}
 
   case "$audit_rc" in
     0) : ;;  # no drift
@@ -130,7 +132,7 @@ if [[ -x "$DOTFILES_DIR/scripts/audit-config-drift.sh" ]]; then
           fi
         fi
       else
-        info "Drift is in the safe direction ($benign declared item(s) pending) — proceeding."
+        info "Drift is non-destructive ($benign declared item(s) pending, $informational informational item(s) preserved) — proceeding."
       fi
       ;;
     *) warn "Audit failed (exit $audit_rc) — proceeding without drift check" ;;


### PR DESCRIPTION
## What changed

- add JSON output to the macOS actual-vs-declared drift audit
- include `config_drift` in daily fleet audit payloads
- normalize scheduled PATH for Nix, Homebrew, and MAS
- classify undeclared state according to whether activation will actually remove it
- update the rebuild summary for informational drift

## Why

The rebuild-time audit found drift only when an operator manually rebuilt a device. Scheduled fleet audits need the same host-specific Nix comparison so drift is visible proactively. The previous classification also treated preserved casks and unmanaged applications as destructive despite `cleanup = "none"`.

## Impact

Managed Macs upload risky, benign, and informational drift daily. Private Internet Access remains an expected manual app, and collector-runner LaunchAgents can resolve the managed Nix/Homebrew tools they audit.

## Validation

- `bash -n` on all four changed scripts
- `git diff --check`
- real `audit-config-drift.sh --json rouvens-mac-studio`
- full `audit-device.sh --local` confirmed structured drift plus Homebrew and MAS collection
- updated collector source passes the config-service read-only scanner

