### PR TITLE
Manage the Mac Studio Lima prerequisite

### DIFF
--- a/configurations/macos/mac-studio.nix
+++ b/configurations/macos/mac-studio.nix
@@ -1,7 +1,16 @@
-{ ... }:
+{ pkgs, ... }:
 
 {
   # ── Mac Studio overrides ─────────────────────────────────────────────────
   # AI inference apps are in modules/roles/ai-inference.nix (imported via flake.nix)
-  # Add any Mac Studio-only overrides here.
+
+  # Lima is the native hypervisor boundary for isolated Linux workloads such as
+  # the knowledge VM. Use nixpkgs rather than Homebrew so the reviewed flake.lock
+  # pins the version and a nix-darwin generation can roll it back.
+  #
+  # This installs only the CLI/runtime. VM definitions, mounts, credentials,
+  # startup policy, and guest lifecycle belong to the workload repository.
+  environment.systemPackages = [
+    pkgs.lima
+  ];
 }

--- a/docs/device-guide.md
+++ b/docs/device-guide.md
@@ -237,6 +237,53 @@ The config service runs on the Mac Studio (`rouvens-mac-studio-1:3456`).
 
 ---
 
+## Mac Studio Lima prerequisite
+
+The `rouvens-mac-studio` nix-darwin configuration installs Lima from `nixpkgs`.
+Its exact version is therefore pinned by the committed `flake.lock`, reviewed
+with the rest of a dotfiles change, and included in the normal nix-darwin
+generation rollback path. Lima is not managed through Homebrew.
+
+Dotfiles owns only the native prerequisite:
+
+- Lima runs on macOS and uses Apple Virtualization.framework when a workload
+  selects the `vz` VM type.
+- Dropbox sync, MLX/Ollama inference, and Tailscale remain native host services.
+- Workload repositories own VM definitions, guest packages, startup policy,
+  networks, credentials, and lifecycle.
+- This repository must not introduce implicit host-directory mounts, SSH-agent
+  forwarding, guest-to-host control credentials, or automatically started VMs.
+
+### Version review and activation
+
+Before activating a lock-file update on the Mac Studio:
+
+1. Evaluate
+   `.#darwinConfigurations.rouvens-mac-studio.pkgs.lima.version` before and
+   after the update and record the version change in the PR.
+2. Ensure every Darwin configuration evaluates and review the normal
+   `rebuild.sh` package-closure diff.
+3. Obtain owner approval because activation changes the live host.
+4. After activation, verify `limactl --version`. Starting or modifying a VM is
+   a separate workload-repository rollout.
+
+The standard fleet audit reports only
+`virtualization_prerequisites.lima.installed` and `.version`. It does not
+enumerate VM names, source paths, mounts, credentials, or guest contents.
+
+### Rollback and uninstall
+
+- Roll back the package with the previous nix-darwin system generation
+  (`sudo darwin-rebuild --rollback`). This does not change or delete guest data.
+- To stop managing Lima, remove `pkgs.lima` from the Mac Studio configuration,
+  review the diff, and rebuild. The executable leaves the managed system
+  closure, while existing `~/.lima` state remains untouched.
+- VM deletion is intentionally not part of dotfiles uninstall. The owning
+  workload must first stop the VM, verify backup/recovery requirements, and
+  explicitly remove its guest state.
+
+---
+
 ## Typical Workflow for Onboarding an Existing Mac
 
 ```bash

--- a/scripts/audit-device.sh
+++ b/scripts/audit-device.sh
@@ -390,6 +390,30 @@ collect_homebrew() {
 JSON
 }
 
+collect_virtualization_prerequisites() {
+  local lima_version=""
+
+  if command -v limactl >/dev/null 2>&1; then
+    # `limactl --version` currently prints "limactl version X.Y.Z". Keep only
+    # the final token so the fleet audit exposes no executable or state paths.
+    lima_version="$(limactl --version 2>/dev/null | awk 'NR == 1 { print $NF }' || true)"
+    python3 - "$lima_version" <<'PY'
+import json
+import sys
+
+version = sys.argv[1].strip()
+print(json.dumps({
+    "lima": {
+        "installed": True,
+        "version": version or None,
+    }
+}))
+PY
+  else
+    echo '{"lima":{"installed":false,"version":null}}'
+  fi
+}
+
 collect_mas() {
   if ! command -v mas &>/dev/null; then echo '{"installed": false}'; return; fi
 
@@ -2250,6 +2274,8 @@ $(collect_audit_scope)
 $(collect_system)
 ---SECTION: homebrew
 $(collect_homebrew)
+---SECTION: virtualization_prerequisites
+$(collect_virtualization_prerequisites)
 ---SECTION: mas_apps
 $(collect_mas)
 ---SECTION: applications


### PR DESCRIPTION
## What changed

- installs `pkgs.lima` only for the Mac Studio through nix-darwin;
- keeps VM definitions, mounts, credentials, startup, and guest lifecycle outside dotfiles;
- adds a body-free fleet-audit field for Lima installed/version state;
- documents the pinned-version review, owner-gated activation, rollback, non-destructive uninstall, and authority boundary.

Refs #50
Parent: rh7/repo-management#16

## Why

The knowledge VM needs a reproducible native hypervisor prerequisite without granting a guest broader Mac access or creating a second workload authority.

## Risk and rollout

This PR changes declarative host configuration and requires owner approval. It does not install Lima, start a VM, alter Dropbox, forward credentials, or change runtime state.

After approval and merge, review the nix-darwin closure diff, activate on the Mac Studio, verify `limactl --version`, and confirm the fleet audit reports only installed/version. Keep #50 open until that live verification passes.

Rollback uses the previous nix-darwin generation. Removing the package intentionally leaves any future guest state untouched.

## Validation

- shell syntax validation for `scripts/audit-device.sh`
- Mac Studio Lima version evaluation: 2.1.2
- Mac Studio system derivation evaluation succeeded
- local body-free audit rendered `virtualization_prerequisites.lima` without VM/source details
- diff whitespace validation
