### PR TITLE
audit: report presence of the role-important backup paths

### DIFF
--- a/scripts/audit-device.sh
+++ b/scripts/audit-device.sh
@@ -1563,6 +1563,31 @@ def age_hours(epoch):
     except Exception:
         return None
 
+# Presence of the paths the server's role policy may treat as important
+# (backup-policy.ts: common + personal + developer + server sets). The server
+# knows WHICH paths a role should protect but not which ones this device has,
+# so without this it cannot tell "never created" from "exists and unprotected"
+# — and reports a critical backup blocker for a directory that doesn't exist.
+#
+# Union of every role's set, so the server can look up whatever its policy
+# produces. isdir() is a stat, not a listing, so this stays permission-safe and
+# needs no --include-protected opt-in.
+result['important_path_presence'] = {
+    p: os.path.isdir(os.path.expanduser(p))
+    for p in [
+        '~/.config/sops/age',
+        '~/.ssh',
+        '~/.config',
+        '~/Documents',
+        '~/Desktop',
+        '~/Pictures',
+        '~/Projects',
+        '~/localtesting',
+        '~/code',
+        '~/mac-studio-services',
+    ]
+}
+
 if sys == 'Darwin':
     # Time Machine
     tm = {'configured': False, 'destinations': []}


### PR DESCRIPTION
Companion to **rh7/rh-device-management#276**.

## Problem

The config service's backup policy (`backup-policy.ts`) lists the paths a **role** should protect, but it has no way to know which of them a given device actually has. Without that signal a path that was never created looks identical to one that exists and is unprotected — so `/api/fleet/backup` reports a critical blocker for a directory that isn't there, and `/api/fleet/retirement` **fails closed** on blockers, so the device can never certify READY.

`rouven-air-m3` shows it: 6 critical `path_unprotected` blockers, 3 of them for `~/Projects`, `~/code` and `~/localtesting` — none of which exist on that Mac. Its own `git_repos.scanned_roots` (which already filters to existing dirs) lists only `~/dotfiles`.

With this field the same device reports 2 blockers, both real (`~/.ssh` and `~/.config` genuinely unprotected).

## Change

Emits `backup_posture.important_path_presence`: the union of every role's important-path set (common + personal + developer + server) mapped to a bool, in the same `~/`-relative notation the server policy uses, so the server can look up whatever its role policy produces.

`isdir()` is a stat, not a directory listing, so this stays permission-safe on macOS and needs **no** `--include-protected` opt-in.

## Verification

- `bash -n` clean
- Ran the collector block on this host: correctly reports `~/Projects: false` (absent) and the rest `true`

The server side is strictly opt-in — an audit without this field keeps the previous behaviour exactly, so merge order doesn't matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)